### PR TITLE
Feat/manage authentication/auth manager

### DIFF
--- a/AIChat/Core/AIChatApp.swift
+++ b/AIChat/Core/AIChatApp.swift
@@ -29,7 +29,7 @@ struct EnvironmentBuilderView<Content: View>: View {
     
     var body: some View {
         content()
-            .environment(\.authService, FirebaseAuthService())
+            .environment(AuthManager(service: FirebaseAuthService()))
     }
 }
 

--- a/AIChat/Core/AppView/AppView.swift
+++ b/AIChat/Core/AppView/AppView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct AppView: View {
     
-    @Environment(\.authService) private var authService
+    @Environment(AuthManager.self) private var authManager
     @State var appState: AppState = .init()
     
     var body: some View {
@@ -36,12 +36,12 @@ struct AppView: View {
     }
     
     private func checkUserStatus() async {
-        if let user = authService.getAuthenticatedUser() {
+        if let user = authManager.auth {
             // User is authenticated
             print("User already authenticated: \(user.uid)")
         } else {
             do {
-                let result = try await authService.signInAnonymously()
+                let result = try await authManager.signInAnonymously()
                 print("Sign in anonymous success: \(result.user.uid)")
             } catch {
                 print(error)

--- a/AIChat/Core/CreateAccount/CreateAccountView.swift
+++ b/AIChat/Core/CreateAccount/CreateAccountView.swift
@@ -11,7 +11,7 @@ import GoogleSignInSwift
 struct CreateAccountView: View {
     
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.authService) private var authService
+    @Environment(AuthManager.self) private var authManager
     var title: String = "Create Account"
     var subtitle: String = "Don't lose your data! Connect to an SSO provider to save your account."
     var onDidSignIn: ((_ isNewUser: Bool) -> Void)?
@@ -58,7 +58,7 @@ struct CreateAccountView: View {
     func onSignInWithAppleTapped() {
         Task {
             do {
-                let result = try await authService.signInWithApple()
+                let result = try await authManager.signInWithApple()
                 print("Signed in with Apple ID: \(result.user.email ?? "Unknown")")
                 onDidSignIn?(result.isNewUser)
                 dismiss()
@@ -71,7 +71,7 @@ struct CreateAccountView: View {
     func onSignInWithGoogleTapped() {
         Task {
             do {
-                let result = try await authService.signInWithGoogle()
+                let result = try await authManager.signInWithGoogle()
                 print("Signed in with Google ID: \(result.user.email ?? "Unknown")")
                 onDidSignIn?(result.isNewUser)
                 dismiss()

--- a/AIChat/Core/Settings/SettingsView.swift
+++ b/AIChat/Core/Settings/SettingsView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SettingsView: View {
     
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.authService) private var authService
+    @Environment(AuthManager.self) private var authManager
     @Environment(AppState.self) private var appState
     
     @State private var isPremium: Bool = false
@@ -129,14 +129,13 @@ struct SettingsView: View {
     }
     
     func setAnonymousAccountStatus() {
-        isAnonymousUser = authService
-            .getAuthenticatedUser()?.isAnonymous == true
+        isAnonymousUser = authManager.auth?.isAnonymous == true
     }
     
     func onSignOutPressed() {
         Task {
             do {
-                try authService.signOut()
+                try authManager.signOut()
                 await dismissScreen()
             } catch {
                 showAlert = AnyAppAlert(error: error)
@@ -167,7 +166,7 @@ struct SettingsView: View {
     private func onDeleteAccountConfirmationPressed() {
         Task {
             do {
-                try await authService.deleteAccount()
+                try await authManager.deleteAccount()
                 await dismissScreen()
             } catch {
                 showAlert = AnyAppAlert(error: error)
@@ -194,18 +193,34 @@ fileprivate extension View {
 
 #Preview("No Auth") {
     SettingsView()
-        .environment(\.authService, MockAuthService(currentUser: nil))
+        .environment(AuthManager(service: MockAuthService(currentUser: nil)))
         .environment(AppState())
 }
 
 #Preview("Anonymous") {
     SettingsView()
-        .environment(\.authService, MockAuthService(currentUser: UserAuthInfo.mock(isAnonymous: true)))
+        .environment(
+            AuthManager(
+                service: MockAuthService(
+                    currentUser: UserAuthInfo.mock(
+                        isAnonymous: true
+                    )
+                )
+            )
+        )
         .environment(AppState())
 }
 
 #Preview("Not anonymous") {
     SettingsView()
-        .environment(\.authService, MockAuthService(currentUser: UserAuthInfo.mock(isAnonymous: false)))
+        .environment(
+            AuthManager(
+                service: MockAuthService(
+                    currentUser: UserAuthInfo.mock(
+                        isAnonymous: false
+                    )
+                )
+            )
+        )
         .environment(AppState())
 }

--- a/AIChat/Services/Auth/AuthManager.swift
+++ b/AIChat/Services/Auth/AuthManager.swift
@@ -1,0 +1,67 @@
+//
+//  AuthManager.swift
+//  AIChat
+//
+//  Created by Abdelrahman Mohamed on 12.06.2025.
+//
+
+import SwiftUI
+
+@MainActor
+@Observable
+class AuthManager {
+    
+    private let service: AuthService
+    private(set) var auth: UserAuthInfo?
+    private var listener: (any NSObjectProtocol)?
+    
+    init(service: AuthService) {
+        self.service = service
+        self.auth = service.getAuthenticatedUser()
+        self.addAuthListener()
+    }
+    
+    private func addAuthListener() {
+        Task {
+            for await value in service.addAuthenticatedUserListener(onListenerAttached: { listener in
+                self.listener = listener
+            }) {
+                self.auth = value
+                print("Auth listener success: \(value?.uid ?? "no uid")")
+            }
+        }
+    }
+    
+    func getAuthId() throws -> String {
+        guard let uid = auth?.uid else {
+            throw AuthError.notSignedIn
+        }
+        return uid
+    }
+    
+    func signInAnonymously() async throws -> (user: UserAuthInfo, isNewUser: Bool) {
+        try await service.signInAnonymously()
+    }
+    
+    func signInWithApple() async throws -> (user: UserAuthInfo, isNewUser: Bool) {
+        try await service.signInWithApple()
+    }
+    
+    func signInWithGoogle() async throws -> (user: UserAuthInfo, isNewUser: Bool) {
+        try await service.signInWithGoogle()
+    }
+    
+    func signOut() throws {
+        try service.signOut()
+        auth = nil
+    }
+    
+    func deleteAccount() async throws {
+        try await service.deleteAccount()
+        auth = nil
+    }
+    
+    enum AuthError: LocalizedError {
+        case notSignedIn
+    }
+}

--- a/AIChat/Services/Auth/Services/AuthService.swift
+++ b/AIChat/Services/Auth/Services/AuthService.swift
@@ -1,5 +1,5 @@
 //
-//  AuthServiceProtocol.swift
+//  AuthService.swift
 //  AIChat
 //
 //  Created by Abdelrahman Mohamed on 11.06.2025.
@@ -7,11 +7,12 @@
 
 import SwiftUI
 
-extension EnvironmentValues {
-    @Entry var authService: AuthServiceProtocol = MockAuthService()
-}
-
-protocol AuthServiceProtocol: Sendable {
+protocol AuthService: Sendable {
+    
+    func addAuthenticatedUserListener(
+        onListenerAttached: (any NSObjectProtocol) -> Void
+    ) -> AsyncStream<UserAuthInfo?>
+    
     func getAuthenticatedUser() -> UserAuthInfo?
     
     func signInAnonymously() async throws -> (user: UserAuthInfo, isNewUser: Bool)

--- a/AIChat/Services/Auth/Services/AuthServiceProtocol.swift
+++ b/AIChat/Services/Auth/Services/AuthServiceProtocol.swift
@@ -1,13 +1,13 @@
 //
-//  AuthService.swift
+//  AuthServiceProtocol.swift
 //  AIChat
 //
 //  Created by Abdelrahman Mohamed on 11.06.2025.
 //
 
-import SwiftUI
+import Foundation
 
-protocol AuthService: Sendable {
+protocol AuthServiceProtocol: Sendable {
     
     func addAuthenticatedUserListener(
         onListenerAttached: (any NSObjectProtocol) -> Void

--- a/AIChat/Services/Auth/Services/FirebaseAuthService.swift
+++ b/AIChat/Services/Auth/Services/FirebaseAuthService.swift
@@ -5,13 +5,13 @@
 //  Created by Abdelrahman Mohamed on 06.06.2025.
 //
 
+import Foundation
 import FirebaseAuth
-import SwiftUI
 import SignInAppleAsync
 import SignInGoogleAsync
 import FirebaseCore
 
-struct FirebaseAuthService: AuthService {
+struct FirebaseAuthService: AuthServiceProtocol {
     
     func addAuthenticatedUserListener(onListenerAttached: (any NSObjectProtocol) -> Void) -> AsyncStream<UserAuthInfo?> {
         AsyncStream { continuation in

--- a/AIChat/Services/Auth/Services/FirebaseAuthService.swift
+++ b/AIChat/Services/Auth/Services/FirebaseAuthService.swift
@@ -11,7 +11,20 @@ import SignInAppleAsync
 import SignInGoogleAsync
 import FirebaseCore
 
-struct FirebaseAuthService: AuthServiceProtocol {
+struct FirebaseAuthService: AuthService {
+    
+    func addAuthenticatedUserListener(onListenerAttached: (any NSObjectProtocol) -> Void) -> AsyncStream<UserAuthInfo?> {
+        AsyncStream { continuation in
+            _ = Auth.auth().addStateDidChangeListener { _, currentUser in
+                if let currentUser {
+                    let user = UserAuthInfo(user: currentUser)
+                    continuation.yield(user)
+                } else {
+                    continuation.yield(nil)
+                }
+            }
+        }
+    }
     
     func getAuthenticatedUser() -> UserAuthInfo? {
         guard let user = Auth.auth().currentUser else {

--- a/AIChat/Services/Auth/Services/MockAuthService.swift
+++ b/AIChat/Services/Auth/Services/MockAuthService.swift
@@ -16,7 +16,7 @@ struct MockAuthService {
     }
 }
 
-extension MockAuthService: AuthService {
+extension MockAuthService: AuthServiceProtocol {
     
     func addAuthenticatedUserListener(onListenerAttached: (any NSObjectProtocol) -> Void) -> AsyncStream<UserAuthInfo?> {
         AsyncStream { continuation in

--- a/AIChat/Services/Auth/Services/MockAuthService.swift
+++ b/AIChat/Services/Auth/Services/MockAuthService.swift
@@ -16,7 +16,13 @@ struct MockAuthService {
     }
 }
 
-extension MockAuthService: AuthServiceProtocol {
+extension MockAuthService: AuthService {
+    
+    func addAuthenticatedUserListener(onListenerAttached: (any NSObjectProtocol) -> Void) -> AsyncStream<UserAuthInfo?> {
+        AsyncStream { continuation in
+            continuation.yield(currentUser)
+        }
+    }
     
     func getAuthenticatedUser() -> UserAuthInfo? {
         currentUser


### PR DESCRIPTION
Let's add another layer to our authentication code so that we have a location to store auth data in memory. We'll call this new object the AuthManager and it will conform to the Observable protocol.

[How to use AsyncStream](https://www.youtube.com/watch?v=gi38bouUI2Q&t=2s) 

[Refactor: AuthManager, extract protocol, and clean up implementation](https://github.com/obadasemary/AIChat/pull/17/commits/e445bdb29e4ff945e58a1bd4e8d319117ed72a33)

- Introduce AuthManagerProtocol for the public API
- Move protocol conformance into an AuthManager extension
- Encapsulate addAuthListener() and AuthError in a private extension
- Remove unnecessary SwiftUI import in favor of Foundation
- Mark AuthManager as final for clarity and minor compiler benefits

In short, you’ve applied a classic “protocol‐oriented” refactoring:
	•	Protocol = the public contract
	•	Extension = conformance and “wiring up” of that contract
	•	Private extension = implementation details that nobody outside this file should see

Functionally, it works exactly the same, but now it’s much easier to swap in a mock for testing, or to hand out AuthManagerProtocol references without exposing all of your internal listener logic.