### PR TITLE
Add Xcode build optimization and iOS clean architecture skills

### DIFF
--- a/.agents/skills/ios-clean-architecture/SKILL.md
+++ b/.agents/skills/ios-clean-architecture/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: ios-clean-architecture
+description: Modular Clean Architecture template for iOS apps built with SwiftUI and Swift Package Manager on Swift 6.2 with default main-actor isolation. Use when scaffolding a new iOS feature, organizing a SwiftUI app into layered SPM packages (NetworkService, Endpoints, Repositories, UseCases, DIContainer, feature views), applying protocol-first cross-module dependencies, wiring up Builder-based feature instantiation, or migrating ObservableObject code to @Observable with Swift 6 concurrency and Swift Testing.
+---
+
+# iOS Clean Architecture (SwiftUI + SPM, Swift 6.2)
+
+This template provides a modular Clean Architecture pattern for iOS apps built with Swift 6.2 and SwiftUI. Here are the key characteristics:
+
+## Core Architecture
+
+The template follows a layered dependency structure where "outer layers depend on inner layers, never the reverse." Data flows unidirectionally from user interactions through ViewModels → UseCases → Repositories → NetworkServices.
+
+## Key Technologies & Patterns
+
+- **Swift 6.2 with default actor isolation** — main-actor isolation applies automatically to all types unless explicitly marked otherwise
+- **SwiftUI with @Observable** — replaces the older `@Published` / `ObservableObject` pattern
+- **Swift Package Manager** — multi-module organization keeps concerns separated
+- **Protocol-first design** — cross-module dependencies always use protocols, never concrete types
+- **Builder pattern** — mandatory feature instantiation through dedicated builders
+- **Service-locator DIContainer** — centralized dependency registration and resolution
+
+## Module Organization
+
+Each responsibility occupies its own SPM package: NetworkService, Endpoints, Repositories, UseCases, DependencyContainer, feature-specific View packages, shared UI components, and preview utilities.
+
+## Testing Approach
+
+The template uses Swift Testing (not XCTest) with test doubles: MockNetworkService, FakeFeedUseCase, and SpyRouter classes that enable isolation of components during verification.
+
+## Critical Constraints
+
+Do not write `@MainActor` manually in Swift 6.2 targets with default isolation enabled. Avoid force unwrapping except within Builder internals. Never allow ViewModels to call URLSession or Repositories directly—route through UseCases. Use `.xcworkspace`, not `.xcodeproj` alone.

--- a/.agents/skills/spm-build-analysis/SKILL.md
+++ b/.agents/skills/spm-build-analysis/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: spm-build-analysis
+description: Analyze Swift Package Manager dependencies, package plugins, module variants, and CI-oriented build overhead that slow Xcode builds. Use when a developer suspects packages, plugins, or dependency graph shape are hurting clean or incremental build performance, mentions SPM slowness, package resolution time, build plugin overhead, duplicate module builds from configuration drift, circular dependencies between modules, oversized modules needing splitting, or modularization best practices.
+---
+
+# SPM Build Analysis
+
+Use this skill when package structure, plugins, or dependency configuration are likely contributing to slow Xcode builds.
+
+## Core Rules
+
+- Treat package analysis as evidence gathering first, not a mandate to replace dependencies.
+- Separate package-graph issues from project-setting issues.
+- Do not rewrite package manifests or dependency sources without explicit approval.
+
+## What To Inspect
+
+- `Package.swift` and `Package.resolved`
+- local packages vs remote packages
+- package plugin and build-tool usage
+- binary target footprint
+- dependency layering, repeated imports, and potential cycles
+- build logs or timing summaries that show package-related work
+
+## Verification Before Recommending
+
+Before including any local package in a recommendation, verify that it is actually part of the project's dependency graph. A `Vendor/` directory may contain packages that are not linked to any target.
+
+- Check `project.pbxproj` for `XCLocalSwiftPackageReference` entries that reference the package path.
+- Check `XCSwiftPackageProductDependency` entries to confirm the package's product is linked to at least one target.
+- If a local package exists on disk but is not referenced in the project, do not include it in build-time recommendations.
+
+When recommending version pins for branch-tracked dependencies:
+
+- Use the helper script to scan all branch-pinned dependencies at once:
+  ```bash
+  python3 scripts/check_spm_pins.py --project App.xcodeproj
+  ```
+  This checks `git ls-remote --tags` for each branch-pinned package and reports which have tags available for pinning.
+- If no tags exist, recommend pinning to a specific commit revision hash for determinism instead.
+- Note which packages are branch-pinned because the upstream simply has no tags, versus packages that have tags but are intentionally tracking a branch.
+
+## Focus Areas
+
+- package graph shape and how much work changes trigger downstream
+- plugin overhead during local development and CI
+- checkout or fetch cost signals that show up in clean environments
+- configuration drift that forces duplicate module builds
+- risks from package targets that use different macros or options while sharing dependencies
+- dependency direction violations (features depending on each other instead of shared lower layers)
+- circular dependencies between modules (extract shared contracts into a protocol module)
+- oversized modules (200+ files) that widen incremental rebuild scope
+- umbrella modules using `@_exported import` that create hidden dependency chains
+- missing interface/implementation separation that blocks build parallelism
+- test targets depending on the app target instead of the module under test
+- Swift macro rebuild cascading: heavy use of Swift macros (e.g., TCA, swift-syntax-based libraries) can cause a trivial source change to cascade into near-full rebuilds because macro expansion invalidates downstream modules
+- `swift-syntax` building universally (all architectures) when no prebuilt binary is available, adding significant clean-build overhead
+- multi-platform build multiplication: adding a secondary platform target (e.g., watchOS) can cause shared SPM packages to build multiple times (e.g., iOS arm64, iOS x86_64, watchOS arm64), multiplying `SwiftCompile`, `SwiftEmitModule`, and `ScanDependencies` tasks
+
+## Modular SDK Migration Caveat
+
+Migrating a dependency from a monolithic target to a modular multi-target SDK (e.g., replacing one umbrella library with separate Core, RUM, Logs, Trace modules) does not automatically reduce build time. Modular targets increase the number of `SwiftCompile`, `SwiftEmitModule`, and `ScanDependencies` tasks because each target must be compiled, scanned, and emit its module independently. The build-time trade-off depends on the project's parallelism headroom and how many of the modular targets are actually needed.
+
+When considering a modular SDK migration:
+
+- Compare the total `SwiftCompile` task count before and after.
+- Benchmark both configurations before recommending the migration for build speed.
+- If the motivation is API surface reduction (importing only what you use), note that build time may stay flat or increase while import hygiene improves.
+- Only recommend modular SDK migration for build speed when the project currently compiles large portions of the monolithic SDK that it does not use, and the modular alternative lets it skip those unused portions entirely.
+
+## Explicit Module Dependency Angle
+
+When the same module appears multiple times in timing output, investigate whether different package or target options are forcing extra module variants. Uniform options often matter more than shaving a small amount of source code.
+
+## Reporting Format
+
+For each finding, include:
+
+- evidence
+- affected package or plugin
+- likely clean-build vs incremental-build impact
+- CI impact if relevant
+- estimated impact
+- approval requirement
+
+If the main problem is not package-related, hand off to [`xcode-project-analyzer`](../xcode-project-analyzer/SKILL.md) or [`xcode-compilation-analyzer`](../xcode-compilation-analyzer/SKILL.md) by reading the target skill's SKILL.md and applying its workflow to the same project context.
+
+## Additional Resources
+
+- For the detailed audit checklist, see [references/spm-analysis-checks.md](references/spm-analysis-checks.md)
+- For the shared recommendation structure, see [references/recommendation-format.md](references/recommendation-format.md)
+- For source citations, see [references/build-optimization-sources.md](references/build-optimization-sources.md)

--- a/.agents/skills/spm-build-analysis/references/build-optimization-sources.md
+++ b/.agents/skills/spm-build-analysis/references/build-optimization-sources.md
@@ -1,0 +1,155 @@
+# Build Optimization Sources
+
+This file stores the external sources that the README and skill docs should cite consistently.
+
+## Apple: Improving the speed of incremental builds
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/improving-the-speed-of-incremental-builds>
+
+Key takeaways:
+
+- Measure first with `Build With Timing Summary` or `xcodebuild -showBuildTimingSummary`.
+- Accurate target dependencies improve correctness and parallelism.
+- Run scripts should declare inputs and outputs so Xcode can skip unnecessary work.
+- `.xcfilelist` files are appropriate when scripts have many inputs or outputs.
+- Custom frameworks and libraries benefit from module maps, typically by enabling `DEFINES_MODULE`.
+- Module reuse is strongest when related sources compile with consistent options.
+- Breaking monolithic targets into better-scoped modules can reduce unnecessary rebuilds.
+
+## Apple: Improving build efficiency with good coding practices
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/improving-build-efficiency-with-good-coding-practices>
+
+Key takeaways:
+
+- Use framework-qualified imports when module maps are available.
+- Keep Objective-C bridging surfaces narrow.
+- Prefer explicit type information when inference becomes expensive.
+- Use explicit delegate protocols instead of overly generic delegate types.
+- Simplify complex expressions that are hard for the compiler to type-check.
+
+## Apple: Building your project with explicit module dependencies
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/building-your-project-with-explicit-module-dependencies>
+
+Key takeaways:
+
+- Explicit module builds make module work visible in the build log and improve scheduling.
+- Repeated builds of the same module often point to avoidable module variants.
+- Inconsistent build options across targets can force duplicate module builds.
+- Timing summaries can reveal option drift that prevents module reuse.
+
+## SwiftLee: Build performance analysis for speeding up Xcode builds
+
+Source:
+
+- <https://www.avanderlee.com/optimization/analysing-build-performance-xcode/>
+
+Key takeaways:
+
+- Clean and incremental builds should both be measured because they reveal different problems.
+- Build Timeline and Build Timing Summary are practical starting points for build optimization.
+- Build scripts often produce large incremental-build wins when guarded correctly.
+- `-warn-long-function-bodies` and `-warn-long-expression-type-checking` help surface compile hotspots.
+- Typical debug and release build setting mismatches are worth auditing, especially in older projects.
+
+## Apple: Xcode Release Notes -- Compilation Caching
+
+Source:
+
+- Xcode Release Notes (149700201)
+
+Key takeaways:
+
+- Compilation caching is an opt-in feature for Swift and C-family languages.
+- It caches prior compilation results and reuses them when the same source inputs are recompiled.
+- Branch switching and clean builds benefit the most.
+- Can be enabled via the "Enable Compilation Caching" build setting or per-user project settings.
+
+## Apple: Demystify explicitly built modules (WWDC24)
+
+Source:
+
+- <https://developer.apple.com/videos/play/wwdc2024/10171/>
+
+Key takeaways:
+
+- Explains how explicitly built modules divide compilation into scan, module build, and source compile stages.
+- Unrelated modules build in parallel, improving CPU utilization.
+- Module variant duplication is a key bottleneck -- uniform compiler options across targets prevent it.
+- The build log shows each module as a discrete task, making it easier to diagnose scheduling issues.
+
+## Swift Compile-Time Best Practices
+
+Well-known Swift language patterns that reduce type-checker workload during compilation:
+
+- Mark classes `final` when they are not intended for subclassing. This eliminates dynamic dispatch overhead and allows the compiler to de-virtualize method calls.
+- Restrict access control to the narrowest useful scope (`private`, `fileprivate`). Fewer visible symbols reduce the compiler's search space during type resolution.
+- Prefer value types (`struct`, `enum`) over `class` when reference semantics are not needed. Value types are simpler for the compiler to reason about.
+- Break long method chains (`.map().flatMap().filter()`) into intermediate `let` bindings with explicit type annotations. Even simple-looking chains can take seconds to type-check.
+- Provide explicit return types on closures passed to generic functions, especially in SwiftUI result-builder contexts.
+- Decompose large SwiftUI `body` properties into smaller extracted subviews. Each subview narrows the scope of the result-builder expression the type-checker must resolve.
+
+## Bitrise: Demystifying Explicitly Built Modules for Xcode
+
+Source:
+
+- <https://bitrise.io/blog/post/demystifying-explicitly-built-modules-for-xcode>
+
+Key takeaways:
+
+- Explicit module builds give `xcodebuild` visibility into smaller compilation tasks for better parallelism.
+- Enabled by default for C/Objective-C in Xcode 16+; experimental for Swift.
+- Minimizing module variants by aligning build options is the primary optimization lever.
+- Some projects see regressions from dependency scanning overhead -- benchmark before and after.
+
+## Bitrise: Xcode Compilation Cache FAQ
+
+Source:
+
+- <https://docs.bitrise.io/en/bitrise-build-cache/build-cache-for-xcode/xcode-compilation-cache-faq.html>
+
+Key takeaways:
+
+- Granular caching is controlled by `SWIFT_ENABLE_COMPILE_CACHE` and `CLANG_ENABLE_COMPILE_CACHE`, under the umbrella `COMPILATION_CACHE_ENABLE_CACHING` setting.
+- Non-cacheable tasks include `CompileStoryboard`, `CompileXIB`, `CompileAssetCatalogVariant`, `PhaseScriptExecution`, `DataModelCompile`, `CopyPNGFile`, `GenerateDSYMFile`, and `Ld`.
+- SPM dependencies are not yet cacheable as of Xcode 26 beta.
+
+## RocketSim Docs: Build Insights
+
+Sources:
+
+- <https://www.rocketsim.app/docs/features/build-insights/build-insights/>
+- <https://www.rocketsim.app/docs/features/build-insights/team-build-insights/>
+
+Key takeaways:
+
+- RocketSim automatically tracks clean vs incremental builds over time without build scripts.
+- It reports build counts, duration trends, and percentile-based metrics such as p75 and p95.
+- Team Build Insights adds machine, Xcode, and macOS comparisons for cross-team visibility.
+- This repository is best positioned as the point-in-time analyze-and-improve toolkit, while RocketSim is the monitor-over-time companion.
+
+## Swift Forums: Slow incremental builds because of planning swift module
+
+Source:
+
+- <https://forums.swift.org/t/slow-incremental-builds-because-of-planning-swift-module/84803>
+
+Key takeaways:
+
+- "Planning Swift module" can dominate incremental builds (up to 30s per module), sometimes exceeding clean build time.
+- Replanning every module without scheduling compiles is a sign that build inputs are being modified unexpectedly (e.g., a misconfigured linter touching file timestamps).
+- Enable **Task Backtraces** (Xcode 16.4+: Scheme Editor > Build > Build Debugging) to see why each task re-ran in an incremental build.
+- Heavy Swift macro usage (e.g., TCA / swift-syntax) can cause trivial changes to cascade into near-full rebuilds.
+- `swift-syntax` builds universally (all architectures) when no prebuilt binary is available, adding significant overhead.
+- `SwiftEmitModule` can take 60s+ after a single-line change in large modules.
+- Asset catalog compilation is single-threaded per target; splitting assets into separate bundles across targets enables parallel compilation.
+- Multi-platform targets (e.g., adding watchOS) can cause SPM packages to build 3x (iOS arm64, iOS x86_64, watchOS arm64).
+- Zero-change incremental builds still incur ~10s of fixed overhead: compute dependencies, send project description, create build description, script phases, codesigning, and validation.
+- Codesigning and validation run even when output has not changed.

--- a/.agents/skills/spm-build-analysis/references/recommendation-format.md
+++ b/.agents/skills/spm-build-analysis/references/recommendation-format.md
@@ -1,0 +1,85 @@
+# Recommendation Format
+
+All optimization skills should report recommendations in a shared structure so the orchestrator can merge and prioritize them cleanly.
+
+## Required Fields
+
+Each recommendation should include:
+
+- `title`
+- `wait_time_impact` -- plain-language statement of expected wall-clock impact, e.g. "Expected to reduce your clean build by ~3s", "Reduces parallel compile work but unlikely to reduce build wait time", or "Impact on wait time is uncertain -- re-benchmark to confirm"
+- `actionability` -- classifies how fixable the issue is from the project (see values below)
+- `category`
+- `observed_evidence`
+- `estimated_impact`
+- `confidence`
+- `approval_required`
+- `benchmark_verification_status`
+
+### Actionability Values
+
+Every recommendation must include an `actionability` classification:
+
+- `repo-local` -- Fix lives entirely in project files, source code, or local configuration. The developer can apply it without side effects outside the repo.
+- `package-manager` -- Requires CocoaPods or SPM configuration changes that may have broad side effects (e.g., linkage mode, dependency restructuring). These should be benchmarked before and after.
+- `xcode-behavior` -- Observed cost is driven by Xcode internals and is not suppressible from the project. Report the finding for awareness but do not promise a fix.
+- `upstream` -- Requires changes in a third-party dependency or external tool. The developer cannot fix it locally.
+
+## Suggested Optional Fields
+
+- `scope`
+- `affected_files`
+- `affected_targets`
+- `affected_packages`
+- `implementation_notes`
+- `risk_level`
+
+## JSON Example
+
+```json
+{
+  "recommendations": [
+    {
+      "title": "Guard a release-only symbol upload script",
+      "wait_time_impact": "Expected to reduce your incremental build by approximately 6 seconds.",
+      "actionability": "repo-local",
+      "category": "project",
+      "observed_evidence": [
+        "Incremental builds spend 6.3 seconds in a run script phase.",
+        "The script runs for Debug builds even though the output is only needed in Release."
+      ],
+      "estimated_impact": "High incremental-build improvement",
+      "confidence": "High",
+      "approval_required": true,
+      "benchmark_verification_status": "Not yet verified",
+      "scope": "Target build phase",
+      "risk_level": "Low"
+    }
+  ]
+}
+```
+
+## Markdown Rendering Guidance
+
+When rendering for human review, preserve the same field order:
+
+1. title
+2. wait-time impact
+3. actionability
+4. observed evidence
+5. estimated impact
+6. confidence
+7. approval required
+8. benchmark verification status
+
+That makes it easier for the developer to approve or reject specific items quickly.
+
+## Verification Status Values
+
+Recommended values:
+
+- `Not yet verified`
+- `Queued for verification`
+- `Verified improvement`
+- `No measurable improvement`
+- `Inconclusive due to benchmark noise`

--- a/.agents/skills/spm-build-analysis/references/spm-analysis-checks.md
+++ b/.agents/skills/spm-build-analysis/references/spm-analysis-checks.md
@@ -1,0 +1,105 @@
+# SPM Analysis Checks
+
+Use this reference when package dependencies or package plugins are suspected build bottlenecks.
+
+## Package Graph Checks
+
+- Identify large umbrella packages that trigger widespread rebuilds.
+- Look for dependency layering that forces many downstream targets to recompile.
+- Flag local package arrangements that cause broad invalidation after small edits.
+
+## Package Plugin Checks
+
+- List build-tool and command plugins involved in the build.
+- Measure whether plugins run during incremental builds even when no relevant input changed.
+- Call out plugins that return quickly but still add fixed overhead to every build.
+
+## Package Reference Verification
+
+- Before including any local package in a build-time recommendation, confirm it appears in the project's `XCLocalSwiftPackageReference` section of `project.pbxproj`.
+- A package existing under `Vendor/` or as a directory in the repo does not mean it is linked. Only referenced packages affect build time.
+- For remote packages, confirm the `XCRemoteSwiftPackageReference` entry exists and at least one `XCSwiftPackageProductDependency` links its product to a target.
+
+## Version Pin Feasibility
+
+- When recommending a switch from `branch:` to a tagged version, verify tags exist via `git ls-remote --tags <url>`.
+- If no tags exist, recommend pinning to a specific `revision:` hash for deterministic resolution.
+- Note the distinction: branch pins force network checks on every fresh resolve; revision pins are fully deterministic but do not benefit from semver range resolution.
+
+## Binary And Remote Dependency Checks
+
+- Note binary target size and extraction overhead for clean environments.
+- Highlight remote checkout or fetch costs that matter for CI or fresh machines.
+- Compare remote vs local package tradeoffs when iteration speed matters more than distribution convenience.
+
+## Module Variant Checks
+
+- Look for the same dependency module being built with different options.
+- Compare macros, language mode, and configuration-sensitive options across dependents.
+- Prefer configuration alignment when it reduces repeated module builds safely.
+
+## Layered Architecture Validation
+
+- Enforce a clear dependency direction: Common/Core --> Services/Domain --> Features/UI. Dependencies must flow in one direction only (inward/downward).
+- Features should never depend on each other directly. If two features share types, move those types to a lower-layer module.
+- Validate that `Package.swift` target dependency lists match the intended layer hierarchy.
+
+## Circular Dependency Detection
+
+- SPM supports cyclic *package* dependencies (since May 2024) but not cyclic *target* dependencies.
+- Circular module dependencies should always be refactored: extract the shared contract (protocols, DTOs) into a separate module that both sides depend on.
+- Check for hidden cycles through transitive dependencies by tracing the full dependency graph.
+
+## Module Sizing Guidance
+
+- Modules larger than roughly 200 files increase incremental build scope unnecessarily -- a single file change recompiles more than needed.
+- Recommend splitting oversized modules by feature area or responsibility.
+- Each module should have a clear, single-purpose responsibility. If a module's name requires "And" or "Utils" to describe, it likely needs splitting.
+
+## Transitive Dependency Minimization
+
+- Each module should depend only on what it directly uses. Unnecessary transitive dependencies widen the rebuild surface.
+- Avoid "umbrella" modules that re-export everything via `@_exported import` -- they create hidden dependency chains where a change in any re-exported module triggers rebuilds in all importers.
+- Use `@_exported import` sparingly and only for genuine convenience wrappers.
+
+## Interface/Implementation Separation
+
+- Define protocols and public types in lightweight "interface" modules (e.g., `NetworkingInterface`).
+- Put implementations in separate modules (e.g., `NetworkingImpl`).
+- Feature modules compile against the interface without waiting for the full implementation to build, improving parallelism.
+- This pattern is most valuable when the implementation module has many files or heavy dependencies that would block downstream compilation.
+
+## Test Target Isolation
+
+- Test targets should depend on the module under test, not the entire app target. Depending on the app target forces a full app build before tests can compile.
+- Shared test utilities (mocks, fixtures, helpers) belong in a dedicated `TestHelpers` module rather than being duplicated across test targets.
+- Keep test-only dependencies out of production target dependency lists.
+
+## Swift Macro Rebuild Impact
+
+- Projects that heavily use Swift macros (e.g., TCA, swift-syntax-based libraries) are susceptible to incremental build cascading where a trivial change rebuilds most of the app.
+- Macro expansion can invalidate downstream modules even when the expanded output has not changed, because the build system treats the macro input as a dependency.
+- Check whether `swift-syntax` is building universally (all architectures) when no prebuilt binary is available. This adds significant overhead to clean builds and CI. Verify with the build log whether the `swift-syntax` target compiles for more architectures than `ONLY_ACTIVE_ARCH` would suggest.
+- If macro-heavy packages dominate incremental build time, consider whether the macro-using code can be isolated into fewer, more stable modules to limit the invalidation blast radius.
+
+## Multi-Platform Build Multiplication
+
+- Adding a secondary platform target (e.g., watchOS, macOS Catalyst) can cause shared SPM packages to build multiple times -- once per platform and architecture combination.
+- A project with iOS and watchOS targets may build shared packages 3x: iOS arm64, iOS x86_64 (simulator), and watchOS arm64.
+- Check the build log for duplicate `SwiftCompile`, `SwiftEmitModule`, and `ScanDependencies` tasks for the same package across different platform/architecture slices.
+- If multi-platform multiplication is a significant contributor, consider whether secondary platform targets can use a subset of shared packages, or whether packages can be prebuilt as binary targets for secondary platforms.
+
+## CI-Specific Checks
+
+- Fresh checkout cost
+- plugin invocation cost
+- cache hit sensitivity
+- redundant package resolution work
+
+## Recommendation Prioritization
+
+Qualify every estimated impact with wall-clock framing. High-priority items should be those likely to reduce the developer's actual wait time, not just cumulative task totals. If the impact on wait time is uncertain, say so.
+
+- High: package plugins or graph structure repeatedly inflating incremental builds, circular dependencies, umbrella re-exports causing cascading rebuilds, Swift macro cascading that causes near-full rebuilds from trivial changes.
+- Medium: configuration drift that causes duplicate module variants, oversized modules, missing interface/implementation separation, multi-platform build multiplication, `swift-syntax` building universally without prebuilt binary.
+- Low: clean-environment checkout costs that barely affect local iteration, minor transitive dependency cleanup.

--- a/.agents/skills/spm-build-analysis/scripts/check_spm_pins.py
+++ b/.agents/skills/spm-build-analysis/scripts/check_spm_pins.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+"""Scan a project.pbxproj for branch-pinned SPM dependencies and check tag availability."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+_PKG_REF_RE = re.compile(
+    r"(/\*\s*XCRemoteSwiftPackageReference\s+\"(?P<name>[^\"]+)\"\s*\*/\s*=\s*\{[^}]*?"
+    r"repositoryURL\s*=\s*\"(?P<url>[^\"]+)\"[^}]*?"
+    r"requirement\s*=\s*\{(?P<req>[^}]*)\})",
+    re.DOTALL,
+)
+
+_KIND_RE = re.compile(r"kind\s*=\s*(\w+)\s*;")
+_BRANCH_RE = re.compile(r"branch\s*=\s*(\w+)\s*;")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check branch-pinned SPM dependencies for available tags."
+    )
+    parser.add_argument(
+        "--project",
+        required=True,
+        help="Path to the .xcodeproj directory",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON",
+    )
+    return parser.parse_args()
+
+
+def find_branch_pins(pbxproj: str) -> List[Dict[str, str]]:
+    results: List[Dict[str, str]] = []
+    for match in _PKG_REF_RE.finditer(pbxproj):
+        name = match.group("name")
+        url = match.group("url")
+        req = match.group("req")
+        kind_match = _KIND_RE.search(req)
+        if not kind_match:
+            continue
+        kind = kind_match.group(1)
+        if kind != "branch":
+            continue
+        branch_match = _BRANCH_RE.search(req)
+        branch = branch_match.group(1) if branch_match else "unknown"
+        results.append({"name": name, "url": url, "branch": branch})
+    return results
+
+
+def check_tags(url: str) -> List[str]:
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", "--tags", url],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return []
+        tags: List[str] = []
+        for line in result.stdout.strip().splitlines():
+            ref = line.split("\t")[-1] if "\t" in line else ""
+            if ref.startswith("refs/tags/") and not ref.endswith("^{}"):
+                tags.append(ref.replace("refs/tags/", ""))
+        return tags
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+
+
+def main() -> int:
+    args = parse_args()
+    pbxproj_path = Path(args.project) / "project.pbxproj"
+    if not pbxproj_path.exists():
+        sys.stderr.write(f"Not found: {pbxproj_path}\n")
+        return 1
+
+    pbxproj = pbxproj_path.read_text()
+    pins = find_branch_pins(pbxproj)
+
+    if not pins:
+        print("No branch-pinned SPM dependencies found.")
+        return 0
+
+    results: List[Dict] = []
+    for pin in pins:
+        tags = check_tags(pin["url"])
+        entry = {
+            "name": pin["name"],
+            "url": pin["url"],
+            "branch": pin["branch"],
+            "tags_available": len(tags) > 0,
+            "latest_tags": tags[-5:] if tags else [],
+        }
+        results.append(entry)
+
+    if args.json:
+        print(json.dumps(results, indent=2))
+    else:
+        for r in results:
+            status = "tags available" if r["tags_available"] else "no tags (pin to revision)"
+            latest = f" (latest: {', '.join(r['latest_tags'])})" if r["latest_tags"] else ""
+            print(f"  {r['name']}: branch={r['branch']} -> {status}{latest}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/xcode-build-benchmark/SKILL.md
+++ b/.agents/skills/xcode-build-benchmark/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: xcode-build-benchmark
+description: Benchmark Xcode clean and incremental builds with repeatable inputs, timing summaries, and timestamped `.build-benchmark/` artifacts. Use when a developer wants a baseline, wants to compare before and after changes, asks to measure build performance, mentions build times, build duration, how long builds take, or wants to know if builds got faster or slower.
+---
+
+# Xcode Build Benchmark
+
+Use this skill to produce a repeatable Xcode build baseline before anyone tries to optimize build times.
+
+## Core Rules
+
+- Measure before recommending changes.
+- Capture clean and incremental builds separately.
+- Keep the command, destination, configuration, scheme, and warm-up rules consistent across runs.
+- Write a timestamped JSON artifact to `.build-benchmark/`.
+- Do not change project files as part of benchmarking.
+
+## Inputs To Collect
+
+Confirm or infer:
+
+- workspace or project path
+- scheme
+- configuration
+- destination
+- whether the user wants simulator or device numbers
+- whether a custom `DerivedData` path is needed
+
+If the project has both clean-build and incremental-build pain, benchmark both. That is the default.
+
+## Worktree Considerations
+
+When benchmarking inside a git worktree, SPM packages with `exclude:` paths that reference gitignored directories (e.g., `__Snapshots__`) will cause `xcodebuild -resolvePackageDependencies` to crash. Create those missing directories before running any builds.
+
+## Default Workflow
+
+1. Normalize the build command and note every flag that affects caching or module reuse.
+2. Run one warm-up build if needed to validate that the command succeeds.
+3. Run 3 clean builds.
+4. If `COMPILATION_CACHE_ENABLE_CACHING = YES` is detected, run 3 cached clean builds. These measure clean build time with a warm compilation cache -- the realistic scenario for branch switching, pulling changes, or Clean Build Folder. The script handles this automatically by building once to warm the cache, then deleting DerivedData (but not the compilation cache) before each measured run. Pass `--no-cached-clean` to skip.
+5. Run 3 zero-change builds (build immediately after a successful build with no edits). This measures the fixed overhead floor: dependency computation, project description transfer, build description creation, script phases, codesigning, and validation. A zero-change build that takes more than a few seconds indicates avoidable per-build overhead. Use the default `benchmark_builds.py` invocation (no `--touch-file` flag).
+6. Optionally run 3 incremental builds with a file touch to measure a real edit-rebuild loop. Use `--touch-file path/to/SomeFile.swift` to touch a representative source file before each build.
+7. Save the raw results and summary into `.build-benchmark/`.
+8. Report medians and spread, not just the single fastest run.
+
+## Preferred Command Path
+
+Use the shared helper when possible:
+
+```bash
+python3 scripts/benchmark_builds.py \
+  --workspace App.xcworkspace \
+  --scheme MyApp \
+  --configuration Debug \
+  --destination "platform=iOS Simulator,name=iPhone 16" \
+  --output-dir .build-benchmark
+```
+
+If you cannot use the helper script, run equivalent `xcodebuild` commands with `-showBuildTimingSummary` and preserve the raw output.
+
+## Required Output
+
+Return:
+
+- clean build median, min, max
+- cached clean build median, min, max (when COMPILATION_CACHE_ENABLE_CACHING is enabled)
+- zero-change build median, min, max (fixed overhead floor)
+- incremental build median, min, max (if `--touch-file` was used)
+- biggest timing-summary categories
+- environment details that could affect comparisons
+- path to the saved artifact
+
+If results are noisy, say so and recommend rerunning under calmer conditions.
+
+## When To Stop
+
+Stop after measurement if the user only asked for benchmarking. If they want optimization guidance, hand off the artifact to the relevant specialist by reading its SKILL.md and applying its workflow to the same project context:
+
+- [`xcode-compilation-analyzer`](../xcode-compilation-analyzer/SKILL.md)
+- [`xcode-project-analyzer`](../xcode-project-analyzer/SKILL.md)
+- [`spm-build-analysis`](../spm-build-analysis/SKILL.md)
+- [`xcode-build-orchestrator`](../xcode-build-orchestrator/SKILL.md) for full orchestration
+
+## Additional Resources
+
+- For the benchmark contract, see [references/benchmarking-workflow.md](references/benchmarking-workflow.md)
+- For the shared artifact format, see [references/benchmark-artifacts.md](references/benchmark-artifacts.md)
+- For the JSON schema, see [schemas/build-benchmark.schema.json](schemas/build-benchmark.schema.json)

--- a/.agents/skills/xcode-build-benchmark/references/benchmark-artifacts.md
+++ b/.agents/skills/xcode-build-benchmark/references/benchmark-artifacts.md
@@ -1,0 +1,94 @@
+# Benchmark Artifacts
+
+All skills in this repository should treat `.build-benchmark/` as the canonical location for measured build evidence.
+
+## Goals
+
+- Keep build measurements reproducible.
+- Make clean and incremental build data easy to compare.
+- Preserve enough context for later specialist analysis without rerunning the benchmark.
+
+## Wall-Clock vs Cumulative Task Time
+
+The `duration_seconds` field on each run and the `median_seconds` in the summary represent **wall-clock time** -- how long the developer actually waits. This is the primary success metric.
+
+The `timing_summary_categories` are **aggregated task times** parsed from Xcode's Build Timing Summary. Because Xcode runs many tasks in parallel across CPU cores, these totals typically exceed the wall-clock duration. A large cumulative `SwiftCompile` value is diagnostic evidence of compiler workload, not proof that compilation is blocking the build. Always compare category totals against the wall-clock median before concluding that a category is a bottleneck.
+
+## File Layout
+
+Recommended outputs:
+
+- `.build-benchmark/<timestamp>-<scheme>.json`
+- `.build-benchmark/<timestamp>-<scheme>-clean-1.log`
+- `.build-benchmark/<timestamp>-<scheme>-clean-2.log`
+- `.build-benchmark/<timestamp>-<scheme>-clean-3.log`
+- `.build-benchmark/<timestamp>-<scheme>-cached-clean-1.log` (when COMPILATION_CACHE_ENABLE_CACHING is enabled)
+- `.build-benchmark/<timestamp>-<scheme>-cached-clean-2.log`
+- `.build-benchmark/<timestamp>-<scheme>-cached-clean-3.log`
+- `.build-benchmark/<timestamp>-<scheme>-incremental-1.log`
+- `.build-benchmark/<timestamp>-<scheme>-incremental-2.log`
+- `.build-benchmark/<timestamp>-<scheme>-incremental-3.log`
+
+Use an ISO-like UTC timestamp without spaces so the files sort naturally.
+
+## Artifact Requirements
+
+Each JSON artifact should include:
+
+- schema version
+- creation timestamp
+- project context
+- environment details when available
+- the normalized build command
+- separate `clean` and `incremental` run arrays
+- summary statistics for each build type
+- parsed timing-summary categories
+- free-form notes for caveats or noise
+
+## Clean, Cached Clean, And Incremental Separation
+
+Do not merge different build type measurements into a single list. They answer different questions:
+
+- **Clean builds** show full build-system, package, and module setup cost with a cold compilation cache.
+- **Cached clean builds** show clean build cost when the compilation cache is warm. This is the realistic scenario for branch switching, pulling changes, or Clean Build Folder. Only present when `COMPILATION_CACHE_ENABLE_CACHING = YES` is detected.
+- **Incremental builds** show edit-loop productivity and script or cache invalidation problems.
+
+## Raw Logs
+
+Store raw `xcodebuild` output beside the JSON artifact whenever possible. That allows later skills to:
+
+- re-parse timing summaries
+- inspect failed builds
+- search for long type-check warnings
+- correlate build-system phases with recommendations
+
+## Measurement Caveats
+
+### COMPILATION_CACHE_ENABLE_CACHING
+
+`COMPILATION_CACHE_ENABLE_CACHING = YES` stores compiled artifacts in a system-managed cache outside DerivedData so that repeated compilations of identical inputs are served from cache. The standard clean-build benchmark (`xcodebuild clean` between runs) may add overhead from cache population without showing the corresponding cache-hit benefit.
+
+The benchmark script automatically detects `COMPILATION_CACHE_ENABLE_CACHING = YES` and runs a **cached clean** benchmark phase. This phase:
+
+1. Builds once to warm the compilation cache.
+2. Deletes DerivedData (but not the compilation cache) before each measured run.
+3. Rebuilds, measuring the cache-hit clean build time.
+
+The cached clean metric captures the realistic developer experience: branch switching, pulling changes, and Clean Build Folder. Use the cached clean median as the primary comparison metric when evaluating `COMPILATION_CACHE_ENABLE_CACHING` impact.
+
+To skip this phase, pass `--no-cached-clean`.
+
+### First-Run Variance
+
+The first clean build after the warmup cycle often runs 20-40% slower than subsequent clean builds due to cold OS-level caches (disk I/O, dynamic linker cache, etc.). The benchmark script mitigates this by running a warmup clean+build cycle before measured runs. If variance between the first and later clean runs is still high, prefer the median or min over the mean, and note the variance in the artifact's `notes` field.
+
+## Shared Consumer Expectations
+
+Any skill reading a benchmark artifact should be able to identify:
+
+- what was measured
+- how it was measured
+- whether the run succeeded
+- whether the results are stable enough to compare
+
+For the authoritative field-level schema, see [../schemas/build-benchmark.schema.json](../schemas/build-benchmark.schema.json).

--- a/.agents/skills/xcode-build-benchmark/references/benchmarking-workflow.md
+++ b/.agents/skills/xcode-build-benchmark/references/benchmarking-workflow.md
@@ -1,0 +1,67 @@
+# Benchmarking Workflow
+
+Use this reference when you need the full operational contract for collecting Xcode build measurements.
+
+## Goal
+
+Produce a benchmark artifact that another skill can trust without rerunning the same setup discovery.
+
+## Benchmark Contract
+
+- Measure both clean and incremental builds unless the user narrows the scope.
+- Use the same scheme, configuration, destination, and command flags for all measured runs.
+- Record the exact command and any environment overrides.
+- Keep clean and incremental runs in separate arrays in the artifact.
+- Save wall-clock timing plus any parsed timing-summary categories.
+
+## Suggested Run Counts
+
+- Clean builds: 3 measured runs
+- Incremental builds: 3 measured runs
+- Warm-up: 0 to 1 validation run, excluded from the summary unless the user explicitly wants it included
+
+## Clean Build Rules
+
+- Clear build products with `xcodebuild clean` or an equivalent clean-build-folder step before each measured clean run.
+- Do not change scheme, destination, or configuration between runs.
+- If the command fails, store the failure and stop rather than mixing failed and successful runs.
+
+## Incremental Build Rules
+
+- Use the same build command after a successful baseline build.
+- Do not clean between incremental runs.
+- If the user wants edit-loop benchmarking, note the file change strategy explicitly in the artifact.
+- If there are no source edits between runs, label the result as no-edit incremental timing.
+
+## What To Capture
+
+At minimum, keep:
+
+- timestamp
+- host machine info if available
+- Xcode version if available
+- workspace or project path
+- scheme, configuration, destination
+- exact `xcodebuild` command
+- duration per run
+- success or failure
+- parsed timing-summary categories
+- notes on warm-up behavior or unusual noise
+
+## Reporting Guidance
+
+Use medians for the headline number. Also include:
+
+- min and max
+- range
+- category totals from the timing summary
+- obvious outliers or instability
+
+## Handoff Expectations
+
+The next optimization skill should be able to answer:
+
+- Is the main problem clean, incremental, or both?
+- Which build categories dominate time?
+- Which command produced the evidence?
+- Is the baseline trustworthy enough to compare before and after changes?

--- a/.agents/skills/xcode-build-benchmark/schemas/build-benchmark.schema.json
+++ b/.agents/skills/xcode-build-benchmark/schemas/build-benchmark.schema.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Xcode Build Benchmark Artifact",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "created_at",
+    "build",
+    "runs",
+    "summary"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": ["1.0.0", "1.1.0", "1.2.0"]
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "build": {
+      "type": "object",
+      "required": [
+        "entrypoint",
+        "scheme",
+        "configuration",
+        "destination",
+        "command"
+      ],
+      "properties": {
+        "entrypoint": {
+          "type": "string",
+          "enum": [
+            "project",
+            "workspace"
+          ]
+        },
+        "path": {
+          "type": "string"
+        },
+        "scheme": {
+          "type": "string"
+        },
+        "configuration": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "derived_data_path": {
+          "type": "string"
+        },
+        "command": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "environment": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "xcode_version": {
+          "type": "string"
+        },
+        "macos_version": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "runs": {
+      "type": "object",
+      "required": [
+        "clean",
+        "incremental"
+      ],
+      "properties": {
+        "clean": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/run"
+          }
+        },
+        "cached_clean": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/run"
+          }
+        },
+        "incremental": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/run"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "clean",
+        "incremental"
+      ],
+      "properties": {
+        "clean": {
+          "$ref": "#/definitions/stats"
+        },
+        "cached_clean": {
+          "$ref": "#/definitions/stats"
+        },
+        "incremental": {
+          "$ref": "#/definitions/stats"
+        }
+      },
+      "additionalProperties": false
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "definitions": {
+    "run": {
+      "type": "object",
+      "required": [
+        "id",
+        "build_type",
+        "duration_seconds",
+        "success",
+        "command"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "build_type": {
+          "type": "string",
+          "enum": [
+            "clean",
+            "cached-clean",
+            "incremental"
+          ]
+        },
+        "duration_seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "success": {
+          "type": "boolean"
+        },
+        "command": {
+          "type": "string"
+        },
+        "exit_code": {
+          "type": "integer"
+        },
+        "raw_log_path": {
+          "type": "string"
+        },
+        "timing_summary_categories": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/category"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "category": {
+      "type": "object",
+      "required": [
+        "name",
+        "seconds"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "task_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": true
+    },
+    "stats": {
+      "type": "object",
+      "required": [
+        "count",
+        "min_seconds",
+        "max_seconds",
+        "median_seconds",
+        "average_seconds"
+      ],
+      "properties": {
+        "count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "min_seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "max_seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "median_seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "average_seconds": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/.agents/skills/xcode-build-benchmark/scripts/benchmark_builds.py
+++ b/.agents/skills/xcode-build-benchmark/scripts/benchmark_builds.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import platform
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark Xcode clean and incremental builds.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to the .xcworkspace file")
+    group.add_argument("--project", help="Path to the .xcodeproj file")
+    parser.add_argument("--scheme", required=True, help="Scheme to build")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--destination", help="xcodebuild destination string")
+    parser.add_argument("--derived-data-path", help="DerivedData path override")
+    parser.add_argument("--output-dir", default=".build-benchmark", help="Output directory for artifacts")
+    parser.add_argument("--repeats", type=int, default=3, help="Measured runs per build type")
+    parser.add_argument("--skip-warmup", action="store_true", help="Skip the validation build")
+    parser.add_argument(
+        "--touch-file",
+        help="Path to a source file to touch before each incremental build. "
+        "When provided, measures a real edit-rebuild loop instead of a zero-change build.",
+    )
+    parser.add_argument(
+        "--no-cached-clean",
+        action="store_true",
+        help="Skip cached clean builds even when COMPILATION_CACHE_ENABLE_CACHING is detected.",
+    )
+    parser.add_argument(
+        "--extra-arg",
+        action="append",
+        default=[],
+        help="Additional xcodebuild argument to append. Can be passed multiple times.",
+    )
+    return parser.parse_args()
+
+
+def command_base(args: argparse.Namespace) -> List[str]:
+    command = ["xcodebuild"]
+    if args.workspace:
+        command.extend(["-workspace", args.workspace])
+    if args.project:
+        command.extend(["-project", args.project])
+    command.extend(["-scheme", args.scheme, "-configuration", args.configuration])
+    if args.destination:
+        command.extend(["-destination", args.destination])
+    if args.derived_data_path:
+        command.extend(["-derivedDataPath", args.derived_data_path])
+    command.extend(args.extra_arg)
+    return command
+
+
+def shell_join(parts: List[str]) -> str:
+    return " ".join(subprocess.list2cmdline([part]) for part in parts)
+
+
+_TASK_COUNT_RE = re.compile(r"^(.+?)\s*\((\d+)\s+tasks?\)$")
+
+
+def _extract_task_count(name: str) -> tuple[str, Optional[int]]:
+    """Split 'Category (N tasks)' into ('Category', N)."""
+    match = _TASK_COUNT_RE.match(name)
+    if match:
+        return match.group(1).strip(), int(match.group(2))
+    return name, None
+
+
+def parse_timing_summary(output: str) -> List[Dict]:
+    categories: Dict[str, float] = {}
+    task_counts: Dict[str, Optional[int]] = {}
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        for suffix in (" seconds", " second", " sec"):
+            if not line.endswith(suffix):
+                continue
+            trimmed = line[: -len(suffix)]
+            if "|" in trimmed:
+                name_part, _, seconds_text = trimmed.rpartition("|")
+            else:
+                name_part, _, seconds_text = trimmed.rpartition(" ")
+            try:
+                seconds = float(seconds_text.strip())
+            except ValueError:
+                continue
+            cleaned_name = name_part.replace("  ", " ").strip(" -:")
+            if len(cleaned_name) < 3:
+                continue
+            base_name, count = _extract_task_count(cleaned_name)
+            categories[base_name] = categories.get(base_name, 0.0) + seconds
+            if count is not None:
+                task_counts[base_name] = (task_counts.get(base_name) or 0) + count
+            break
+    result: List[Dict] = []
+    for name, seconds in sorted(categories.items(), key=lambda item: item[1], reverse=True):
+        entry: Dict = {"name": name, "seconds": round(seconds, 3)}
+        if name in task_counts:
+            entry["task_count"] = task_counts[name]
+        result.append(entry)
+    return result
+
+
+def run_command(command: List[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(command, capture_output=True, text=True)
+
+
+def stats_for(runs: List[Dict[str, object]]) -> Dict[str, float]:
+    durations = [run["duration_seconds"] for run in runs if run.get("success")]
+    if not durations:
+        return {
+            "count": 0,
+            "min_seconds": 0.0,
+            "max_seconds": 0.0,
+            "median_seconds": 0.0,
+            "average_seconds": 0.0,
+        }
+    return {
+        "count": len(durations),
+        "min_seconds": round(min(durations), 3),
+        "max_seconds": round(max(durations), 3),
+        "median_seconds": round(statistics.median(durations), 3),
+        "average_seconds": round(statistics.fmean(durations), 3),
+    }
+
+
+def xcode_version() -> str:
+    result = run_command(["xcodebuild", "-version"])
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def detect_compilation_caching(base_command: List[str]) -> bool:
+    """Check whether COMPILATION_CACHE_ENABLE_CACHING is enabled in the resolved build settings."""
+    result = run_command([*base_command, "-showBuildSettings"])
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("COMPILATION_CACHE_ENABLE_CACHING") and "=" in stripped:
+            value = stripped.split("=", 1)[1].strip()
+            return value == "YES"
+    return False
+
+
+def measure_build(
+    base_command: List[str],
+    artifact_stem: str,
+    output_dir: Path,
+    build_type: str,
+    run_index: int,
+) -> Dict[str, object]:
+    build_command = [*base_command, "build", "-showBuildTimingSummary"]
+    started = time.perf_counter()
+    result = run_command(build_command)
+    elapsed = round(time.perf_counter() - started, 3)
+    log_path = output_dir / f"{artifact_stem}-{build_type}-{run_index}.log"
+    log_path.write_text(result.stdout + result.stderr)
+    return {
+        "id": f"{build_type}-{run_index}",
+        "build_type": build_type,
+        "duration_seconds": elapsed,
+        "success": result.returncode == 0,
+        "exit_code": result.returncode,
+        "command": shell_join(build_command),
+        "raw_log_path": str(log_path),
+        "timing_summary_categories": parse_timing_summary(result.stdout + result.stderr),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    artifact_stem = f"{timestamp}-{args.scheme.replace(' ', '-').lower()}"
+    base_command = command_base(args)
+
+    if not args.skip_warmup:
+        warmup = run_command([*base_command, "build"])
+        if warmup.returncode != 0:
+          sys.stderr.write(warmup.stdout + warmup.stderr)
+          return warmup.returncode
+        warmup_clean = run_command([*base_command, "clean"])
+        if warmup_clean.returncode != 0:
+            sys.stderr.write(warmup_clean.stdout + warmup_clean.stderr)
+            return warmup_clean.returncode
+        warmup_rebuild = run_command([*base_command, "build"])
+        if warmup_rebuild.returncode != 0:
+            sys.stderr.write(warmup_rebuild.stdout + warmup_rebuild.stderr)
+            return warmup_rebuild.returncode
+
+    runs: Dict[str, list] = {"clean": [], "incremental": []}
+
+    for index in range(1, args.repeats + 1):
+        clean_result = run_command([*base_command, "clean"])
+        clean_log_path = output_dir / f"{artifact_stem}-clean-prep-{index}.log"
+        clean_log_path.write_text(clean_result.stdout + clean_result.stderr)
+        if clean_result.returncode != 0:
+            sys.stderr.write(clean_result.stdout + clean_result.stderr)
+            return clean_result.returncode
+        runs["clean"].append(measure_build(base_command, artifact_stem, output_dir, "clean", index))
+
+    # --- Cached clean builds ---------------------------------------------------
+    # When COMPILATION_CACHE_ENABLE_CACHING is enabled, the compilation cache lives outside
+    # DerivedData and survives product deletion.  We measure "cached clean"
+    # builds by pointing DerivedData at a temp directory, warming the cache with
+    # one build, then deleting the DerivedData directory (but not the cache)
+    # before each measured rebuild.  This captures the realistic scenario:
+    # branch switching, pulling changes, or Clean Build Folder.
+    should_cached_clean = not args.no_cached_clean and detect_compilation_caching(base_command)
+    if should_cached_clean:
+        dd_path = Path(args.derived_data_path) if args.derived_data_path else Path(
+            tempfile.mkdtemp(prefix="xcode-bench-dd-")
+        )
+        cached_cmd = list(base_command)
+        if not args.derived_data_path:
+            cached_cmd.extend(["-derivedDataPath", str(dd_path)])
+
+        cache_warmup = run_command([*cached_cmd, "build"])
+        if cache_warmup.returncode != 0:
+            sys.stderr.write("Warning: cached clean warmup build failed, skipping cached clean benchmarks.\n")
+            sys.stderr.write(cache_warmup.stdout + cache_warmup.stderr)
+            should_cached_clean = False
+
+    if should_cached_clean:
+        runs["cached_clean"] = []
+        for index in range(1, args.repeats + 1):
+            shutil.rmtree(dd_path, ignore_errors=True)
+            runs["cached_clean"].append(
+                measure_build(cached_cmd, artifact_stem, output_dir, "cached-clean", index)
+            )
+        shutil.rmtree(dd_path, ignore_errors=True)
+
+    # --- Incremental / zero-change builds --------------------------------------
+    incremental_label = "incremental"
+    if args.touch_file:
+        touch_path = Path(args.touch_file)
+        if not touch_path.exists():
+            sys.stderr.write(f"--touch-file path does not exist: {touch_path}\n")
+            return 1
+        incremental_label = "incremental"
+    else:
+        incremental_label = "zero-change"
+
+    for index in range(1, args.repeats + 1):
+        if args.touch_file:
+            touch_path.touch()
+        runs["incremental"].append(
+            measure_build(base_command, artifact_stem, output_dir, incremental_label, index)
+        )
+
+    summary: Dict[str, object] = {
+        "clean": stats_for(runs["clean"]),
+        "incremental": stats_for(runs["incremental"]),
+    }
+    if "cached_clean" in runs:
+        summary["cached_clean"] = stats_for(runs["cached_clean"])
+
+    artifact = {
+        "schema_version": "1.2.0" if "cached_clean" in runs else "1.1.0",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "build": {
+            "entrypoint": "workspace" if args.workspace else "project",
+            "path": args.workspace or args.project,
+            "scheme": args.scheme,
+            "configuration": args.configuration,
+            "destination": args.destination or "",
+            "derived_data_path": args.derived_data_path or "",
+            "command": shell_join(base_command),
+        },
+        "environment": {
+            "host": platform.node(),
+            "macos_version": platform.platform(),
+            "xcode_version": xcode_version(),
+            "cwd": os.getcwd(),
+        },
+        "runs": runs,
+        "summary": summary,
+        "notes": [f"touch-file: {args.touch_file}"] if args.touch_file else [],
+    }
+
+    artifact_path = output_dir / f"{artifact_stem}.json"
+    artifact_path.write_text(json.dumps(artifact, indent=2) + "\n")
+
+    print(f"Saved benchmark artifact: {artifact_path}")
+    print(f"Clean median: {artifact['summary']['clean']['median_seconds']}s")
+    if "cached_clean" in artifact["summary"]:
+        print(f"Cached clean median: {artifact['summary']['cached_clean']['median_seconds']}s")
+    inc_label = "Incremental" if args.touch_file else "Zero-change"
+    print(f"{inc_label} median: {artifact['summary']['incremental']['median_seconds']}s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/xcode-build-fixer/SKILL.md
+++ b/.agents/skills/xcode-build-fixer/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: xcode-build-fixer
+description: Apply approved Xcode build optimization changes following best practices, then re-benchmark to verify improvement. Use when a developer has an approved optimization plan from xcode-build-orchestrator, wants to apply specific build fixes, needs help implementing build setting changes, script phase guards, source-level compilation fixes, or SPM restructuring that was recommended by an analysis skill.
+---
+
+# Xcode Build Fixer
+
+Use this skill to implement approved build optimization changes and verify them with a benchmark.
+
+## Core Rules
+
+- Only apply changes that have explicit developer approval.
+- Apply one logical fix at a time so changes are reviewable and reversible.
+- Re-benchmark after applying changes to verify improvement.
+- Report exactly what changed, which files were touched, and the measured delta.
+- If a change produces no improvement or causes a regression, flag it immediately.
+
+## Inputs
+
+The fixer expects one of:
+
+- An approved optimization plan at `.build-benchmark/optimization-plan.md` with checked approval boxes.
+- An explicit developer instruction describing the fix to apply (e.g., "set `DEBUG_INFORMATION_FORMAT` to `dwarf` for Debug").
+
+When working from an optimization plan, read the approval checklist and implement only the checked items.
+
+## Fix Categories
+
+### Build Settings
+
+Change `project.pbxproj` values to match the recommendations in [build-settings-best-practices.md](references/build-settings-best-practices.md).
+
+Typical fixes:
+
+- Set `DEBUG_INFORMATION_FORMAT = dwarf` for Debug
+- Set `SWIFT_COMPILATION_MODE = singlefile` for Debug
+- Enable `COMPILATION_CACHE_ENABLE_CACHING = YES`
+- Enable `EAGER_LINKING = YES` for Debug
+- Align cross-target settings to eliminate module variants
+
+When editing `project.pbxproj`, locate the correct `buildSettings` block by matching the target name and configuration name. Verify the change with `xcodebuild -showBuildSettings` after applying.
+
+### Script Phases
+
+Fix run script phases that waste time during incremental or debug builds.
+
+Typical fixes:
+
+- Add input and output file declarations so Xcode can skip unchanged scripts.
+- Add configuration guards: `[[ "$CONFIGURATION" != "Release" ]] && exit 0` for release-only scripts.
+- Move input/output lists into `.xcfilelist` files when the list is long.
+- Enable `Based on dependency analysis` when inputs and outputs are declared.
+
+### Source-Level Compilation Fixes
+
+Apply code changes that reduce type-checker and compiler overhead. See [references/fix-patterns.md](references/fix-patterns.md) for before/after patterns.
+
+Typical fixes:
+
+- Add explicit type annotations to complex expressions.
+- Break long chained or nested expressions into intermediate typed variables.
+- Mark classes `final` when they are not subclassed.
+- Tighten access control (`private`/`fileprivate`) for internal-only symbols.
+- Extract monolithic SwiftUI `body` properties into smaller composed subviews.
+- Replace deeply nested result-builder code with separate typed helpers.
+- Add explicit return types to closures passed to generic functions.
+
+### SPM Restructuring
+
+Restructure Swift packages to improve build parallelism and reduce rebuild scope.
+
+Typical fixes:
+
+- Move shared types to a lower-layer module to eliminate circular or upward dependencies.
+- Split oversized modules (200+ files) by feature area.
+- Extract protocol definitions into lightweight interface modules.
+- Remove unnecessary `@_exported import` usage.
+- Align build options across targets that import the same packages to prevent module variant duplication.
+- Pin branch-tracked dependencies to tagged versions or commit hashes for deterministic resolution.
+
+Before applying version pin changes:
+
+- Run `git ls-remote --tags <url>` to confirm tags exist. If the upstream has no tags, pin to a specific revision hash instead.
+- Verify the pinned version resolves successfully with `xcodebuild -resolvePackageDependencies` before proceeding.
+
+## Execution Workflow
+
+1. Read the approved optimization plan or developer instruction.
+2. For each approved item, identify the exact files and locations to change.
+3. Apply the change.
+4. Verify the change compiles: run a quick `xcodebuild build` to confirm no errors were introduced.
+5. After all approved changes are applied, re-benchmark using the same inputs from the original baseline:
+   ```bash
+   python3 scripts/benchmark_builds.py \
+     --project App.xcodeproj \
+     --scheme MyApp \
+     --configuration Debug \
+     --destination "platform=iOS Simulator,name=iPhone 16" \
+     --output-dir .build-benchmark
+   ```
+6. Compare post-change medians to the baseline and report deltas.
+
+## Evaluating Regressions
+
+Not every slower number is a true regression. The fixer must evaluate the full picture before recommending a revert.
+
+### Compilation caching trade-off
+
+A change like `COMPILATION_CACHE_ENABLE_CACHING = YES` may make a standard clean build slightly slower (cache population overhead) while making cached clean builds significantly faster. Since cached clean builds reflect the realistic developer workflow (branch switching, pulling changes, Clean Build Folder with a warm cache), a slower standard clean build paired with a faster cached clean build is a net improvement, not a regression. The same logic applies to any change where the first-time cost is higher but subsequent builds benefit.
+
+### Compare all build types
+
+Evaluate standard clean, cached clean (when available), and incremental builds together. A change is only a clear regression if it makes the metrics that matter to the developer's daily workflow worse. If only the cold-start clean build is slower but the developer rarely does truly cold builds, that may be acceptable.
+
+### Per-change vs. cumulative
+
+A single change that regresses on its own may still be worth keeping if it enables a larger cumulative improvement (e.g., enabling compilation caching makes one build type slower but unlocks cache benefits for everything else).
+
+### Best-practice settings are not revert candidates
+
+Some build settings are Apple's recommended modern defaults. These should be applied and kept regardless of whether the immediate benchmark shows a measurable improvement. They are not speculative optimizations -- they align the project with Apple's toolchain direction and will compound in value over future Xcode releases. The fixer must never recommend reverting these settings based on a single benchmark result.
+
+Best-practice settings that should always be kept once applied:
+
+- `COMPILATION_CACHE_ENABLE_CACHING = YES` -- Apple is actively investing in this; the cache improves with each Xcode release and compounds across real workflows
+- `EAGER_LINKING = YES` (Debug) -- allows the linker to overlap with compilation
+- `SWIFT_USE_INTEGRATED_DRIVER = YES` -- eliminates inter-process scheduling overhead
+- `DEBUG_INFORMATION_FORMAT = dwarf` (Debug) -- avoids unnecessary dSYM generation
+- `SWIFT_COMPILATION_MODE = singlefile` (Debug) -- incremental recompilation
+- `ONLY_ACTIVE_ARCH = YES` (Debug) -- no reason to build all architectures locally
+
+When reporting on these settings, use language like: "Applied recommended build setting. No immediate benchmark improvement measured, but this aligns with Apple's recommended configuration and positions the project for future Xcode improvements."
+
+### When to recommend revert (speculative changes only)
+
+For changes that are not best-practice settings (e.g., source refactors, linkage experiments, script phase modifications, dependency restructuring):
+
+- If the cumulative pass shows wall-clock regression across all measured build types (standard clean, cached clean, and incremental are all slower), recommend reverting all speculative changes unless the developer explicitly asks to keep specific items for non-performance reasons.
+- For each individual speculative change: if it shows no median improvement and no cached/incremental benefit either, flag it with `Recommend revert` and the measured delta.
+- Distinguish between "outlier reduction only" (improved worst-case but not median) and "median improvement" (improved typical developer wait).
+- When a change trades off one build type for another (e.g., slower standard clean but faster cached clean), present both numbers clearly and let the developer decide. Frame it as: "Standard clean builds are X.Xs slower, but cached clean builds (the realistic daily workflow) are Y.Ys faster."
+
+## Reporting
+
+Lead with the wall-clock result in plain language:
+
+> "Your clean build now takes X.Xs (was Y.Ys) -- Z.Zs faster."
+> "Your incremental build now takes X.Xs (was Y.Ys) -- Z.Zs faster."
+
+Then include:
+
+- Post-change clean build wall-clock median
+- Post-change incremental build wall-clock median
+- Absolute and percentage wall-clock deltas for both
+- Confidence notes if benchmark noise is high
+- List of files modified per fix
+- Any deviations from the original recommendation
+
+If cumulative task metrics improved but wall-clock did not, say plainly: "Compiler workload decreased but build wait time did not improve. This is expected when Xcode runs these tasks in parallel with other equally long work."
+
+If a fix produced no measurable wall-time improvement, note `No measurable wall-time improvement` and suggest whether to keep (e.g. for code quality) or revert.
+
+For changes valuable for non-benchmark reasons (deterministic package resolution, branch-switch caching), label them: "No wait-time improvement expected from this change. The benefit is [deterministic builds / faster branch switching / reduced CI cost]."
+
+Note: `COMPILATION_CACHE_ENABLE_CACHING` has been measured at 5-14% faster clean builds across tested projects (87 to 1,991 Swift files). The benefit compounds in real developer workflows where the cache persists between builds -- branch switching, pulling changes, and CI with persistent DerivedData. The benchmark script auto-detects this setting and runs a cached clean phase for validation.
+
+## Execution Report
+
+After the optimization pass is complete, produce a structured execution report. This gives the developer a clear summary of what was attempted, what worked, and what the final state is.
+
+Structure:
+
+```markdown
+## Execution Report
+
+### Baseline
+- Clean build median: X.Xs
+- Cached clean build median: X.Xs (if applicable)
+- Incremental build median: X.Xs
+
+### Changes Applied
+
+| # | Change | Actionability | Measured Result | Status |
+|---|--------|---------------|-----------------|--------|
+| 1 | Description | repo-local | Clean: X.Xs→Y.Ys, Incr: X.Xs→Y.Ys | Kept / Reverted / Blocked |
+| 2 | ... | ... | ... | ... |
+
+### Final Cumulative Result
+- Clean build median: X.Xs (was Y.Ys) -- Z.Zs faster/slower
+- Cached clean build median: X.Xs (was Y.Ys) -- Z.Zs faster/slower
+- Incremental build median: X.Xs (was Y.Ys) -- Z.Zs faster/slower
+- **Net result:** Faster / Slower / Unchanged
+
+### Blocked or Non-Actionable Findings
+- Finding: reason it could not be addressed from the repo
+```
+
+Status values:
+
+- `Kept` -- Change improved or maintained build times and was kept.
+- `Kept (best practice)` -- Change is a recommended build setting; kept regardless of immediate benchmark result.
+- `Reverted` -- Change regressed build times and was reverted.
+- `Blocked` -- Change could not be applied due to project structure, Xcode behavior, or external constraints.
+- `No improvement` -- Change compiled but showed no measurable wall-time benefit. Include whether it was kept (for non-performance reasons) or reverted.
+
+## Escalation
+
+If during implementation you discover issues outside this skill's scope:
+
+- Project-level analysis gaps: hand off to [`xcode-project-analyzer`](../xcode-project-analyzer/SKILL.md)
+- Compilation hotspot analysis: hand off to [`xcode-compilation-analyzer`](../xcode-compilation-analyzer/SKILL.md)
+- Package graph issues: hand off to [`spm-build-analysis`](../spm-build-analysis/SKILL.md)
+
+## Additional Resources
+
+- For concrete before/after fix patterns, see [references/fix-patterns.md](references/fix-patterns.md)
+- For build settings best practices, see [references/build-settings-best-practices.md](references/build-settings-best-practices.md)
+- For the recommendation format, see [references/recommendation-format.md](references/recommendation-format.md)

--- a/.agents/skills/xcode-build-fixer/references/build-settings-best-practices.md
+++ b/.agents/skills/xcode-build-fixer/references/build-settings-best-practices.md
@@ -1,0 +1,216 @@
+# Build Settings Best Practices
+
+This reference lists Xcode build settings that affect build performance. Use it to audit a project and produce a pass/fail checklist.
+
+The scope is strictly **build performance**. Do not flag language-migration settings like `SWIFT_STRICT_CONCURRENCY` or `SWIFT_UPCOMING_FEATURE_*` -- those are developer adoption choices unrelated to build speed.
+
+## How To Read This Reference
+
+Each setting includes:
+
+- **Setting name** and the Xcode build-settings key
+- **Recommended value** for Debug and Release
+- **Why it matters** for build time
+- **Risk** of changing it
+
+Use checkmark and cross indicators when reporting:
+
+- `[x]` -- setting matches the recommended value
+- `[ ]` -- setting does not match; include the actual value and the expected value
+
+## Debug Configuration
+
+These settings optimize for fast iteration during development.
+
+### Compilation Mode
+
+- **Key:** `SWIFT_COMPILATION_MODE`
+- **Recommended:** `singlefile` (Xcode UI: "Incremental"; or unset -- Xcode defaults to singlefile for Debug)
+- **Why:** Single-file mode recompiles only changed files. `wholemodule` recompiles the entire target on every change.
+- **Risk:** Low
+
+### Swift Optimization Level
+
+- **Key:** `SWIFT_OPTIMIZATION_LEVEL`
+- **Recommended:** `-Onone`
+- **Why:** Optimization passes add significant compile time. Debug builds do not benefit from runtime speed improvements.
+- **Risk:** Low
+
+### GCC Optimization Level
+
+- **Key:** `GCC_OPTIMIZATION_LEVEL`
+- **Recommended:** `0`
+- **Why:** Same rationale as Swift optimization level, but for C/C++/Objective-C sources.
+- **Risk:** Low
+
+### Build Active Architecture Only
+
+- **Key:** `ONLY_ACTIVE_ARCH` (`BUILD_ACTIVE_ARCHITECTURE_ONLY`)
+- **Recommended:** `YES`
+- **Why:** Building all architectures doubles or triples compile and link time for no debug benefit.
+- **Risk:** Low
+
+### Debug Information Format
+
+- **Key:** `DEBUG_INFORMATION_FORMAT`
+- **Recommended:** `dwarf`
+- **Why:** `dwarf-with-dsym` generates a separate dSYM bundle which adds overhead. Plain `dwarf` embeds debug info directly in the binary, which is sufficient for local debugging.
+- **Risk:** Low
+
+### Enable Testability
+
+- **Key:** `ENABLE_TESTABILITY`
+- **Recommended:** `YES`
+- **Why:** Required for `@testable import`. Adds minor overhead by exporting internal symbols, but this is expected during development.
+- **Risk:** Low
+
+### Active Compilation Conditions
+
+- **Key:** `SWIFT_ACTIVE_COMPILATION_CONDITIONS`
+- **Recommended:** Should include `DEBUG`
+- **Why:** Guards conditional compilation blocks (e.g., `#if DEBUG`) and ensures debug-only code paths are included.
+- **Risk:** Low
+
+### Eager Linking
+
+- **Key:** `EAGER_LINKING`
+- **Recommended:** `YES`
+- **Why:** Allows the linker to start work before all compilation tasks finish, reducing wall-clock build time. Particularly effective for Debug builds where link time is a meaningful fraction of total build time.
+- **Risk:** Low
+
+## Release Configuration
+
+These settings optimize for production builds.
+
+### Compilation Mode
+
+- **Key:** `SWIFT_COMPILATION_MODE`
+- **Recommended:** `wholemodule`
+- **Why:** Whole-module optimization produces faster runtime code. Build time is secondary for release.
+- **Risk:** Low
+
+### Swift Optimization Level
+
+- **Key:** `SWIFT_OPTIMIZATION_LEVEL`
+- **Recommended:** `-O` or `-Osize`
+- **Why:** Produces optimized binaries. `-Osize` trades some speed for smaller binary size.
+- **Risk:** Low
+
+### GCC Optimization Level
+
+- **Key:** `GCC_OPTIMIZATION_LEVEL`
+- **Recommended:** `s`
+- **Why:** Optimizes C/C++/Objective-C for size, matching the typical release expectation.
+- **Risk:** Low
+
+### Build Active Architecture Only
+
+- **Key:** `ONLY_ACTIVE_ARCH`
+- **Recommended:** `NO`
+- **Why:** Release builds must include all supported architectures for distribution.
+- **Risk:** Low
+
+### Debug Information Format
+
+- **Key:** `DEBUG_INFORMATION_FORMAT`
+- **Recommended:** `dwarf-with-dsym`
+- **Why:** dSYM bundles are required for crash symbolication in production.
+- **Risk:** Low
+
+### Enable Testability
+
+- **Key:** `ENABLE_TESTABILITY`
+- **Recommended:** `NO`
+- **Why:** Removes internal-symbol export overhead from release builds. Testing should use Debug configuration.
+- **Risk:** Low
+
+## General (All Configurations)
+
+### Compilation Caching
+
+- **Key:** `COMPILATION_CACHE_ENABLE_CACHING`
+- **Recommended:** `YES`
+- **Why:** Caches compilation results for Swift and C-family sources so repeated compilations of the same inputs are served from cache. The biggest wins come from branch switching and clean builds where source files are recompiled unchanged. This is an opt-in feature. The umbrella setting controls both `SWIFT_ENABLE_COMPILE_CACHE` and `CLANG_ENABLE_COMPILE_CACHE` under the hood; those can be toggled independently if needed.
+- **Measurement:** Measured 5-14% faster clean builds across tested projects (87 to 1,991 Swift files). The benefit compounds in real developer workflows where the cache persists between builds -- branch switching, pulling changes, and CI with persistent DerivedData -- though the exact savings depend on how many files change between builds.
+- **Risk:** Low -- can also be enabled via per-user project settings so it does not need to be committed to the shared project file.
+
+### Integrated Swift Driver
+
+- **Key:** `SWIFT_USE_INTEGRATED_DRIVER`
+- **Recommended:** `YES`
+- **Why:** Uses the integrated Swift driver which runs inside the build system process, eliminating inter-process overhead for compilation scheduling. Enabled by default in modern Xcode but worth verifying in migrated projects.
+- **Risk:** Low
+
+### Clang Module Compilation
+
+- **Key:** `CLANG_ENABLE_MODULES`
+- **Recommended:** `YES`
+- **Why:** Enables Clang module compilation for C/Objective-C sources, caching module maps on disk instead of reprocessing headers on every import. Eliminates redundant header parsing across translation units.
+- **Risk:** Low
+
+### Explicit Module Builds
+
+- **Key:** `SWIFT_ENABLE_EXPLICIT_MODULES` (C/ObjC enabled by default in Xcode 16+; for Swift use `_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES`)
+- **Recommended:** Evaluate per-project
+- **Why:** Makes module compilation visible to the build system as discrete tasks, improving parallelism and scheduling. Reduces redundant module rebuilds by making dependency edges explicit. Some projects see regressions due to the overhead of dependency scanning, so benchmark before and after enabling.
+- **Risk:** Medium -- test thoroughly; currently experimental for Swift targets.
+
+## Cross-Target Consistency
+
+These checks find settings differences between targets that cause redundant build work.
+
+### Project-Level vs Target-Level Overrides
+
+Build-affecting settings should be set at the project level unless a target has a specific reason to override. Unnecessary per-target overrides cause confusion and can silently create module variants.
+
+Settings to check for project-level consistency:
+
+- `SWIFT_COMPILATION_MODE`
+- `SWIFT_OPTIMIZATION_LEVEL`
+- `ONLY_ACTIVE_ARCH`
+- `DEBUG_INFORMATION_FORMAT`
+
+### Module Variant Duplication
+
+When multiple targets import the same SPM package but compile with different Swift compiler options, the build system produces separate module variants for each combination. This inflates `SwiftEmitModule` task counts.
+
+Check for drift in:
+
+- `SWIFT_OPTIMIZATION_LEVEL`
+- `SWIFT_COMPILATION_MODE`
+- `OTHER_SWIFT_FLAGS`
+- Target-level build settings that override project defaults
+
+### Out of Scope
+
+Do **not** flag the following as build-performance issues:
+
+- `SWIFT_STRICT_CONCURRENCY` -- language migration choice
+- `SWIFT_UPCOMING_FEATURE_*` -- language migration choice
+- `SWIFT_APPROACHABLE_CONCURRENCY` -- language migration choice
+- `SWIFT_ACTIVE_COMPILATION_CONDITIONS` values beyond `DEBUG` (e.g., `WIDGETS`, `APPCLIP`) -- intentional per-target customization
+
+## Checklist Output Format
+
+When reporting results, use this structure:
+
+```markdown
+### Debug Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `singlefile` (recommended: `singlefile`)
+- [ ] `DEBUG_INFORMATION_FORMAT`: `dwarf-with-dsym` (recommended: `dwarf`)
+- [x] `SWIFT_OPTIMIZATION_LEVEL`: `-Onone` (recommended: `-Onone`)
+...
+
+### Release Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `wholemodule` (recommended: `wholemodule`)
+...
+
+### General (All Configurations)
+- [ ] `COMPILATION_CACHE_ENABLE_CACHING`: `NO` (recommended: `YES`)
+...
+
+### Cross-Target Consistency
+- [x] All targets inherit `SWIFT_OPTIMIZATION_LEVEL` from project level
+- [ ] `OTHER_SWIFT_FLAGS` differs between Stock Analyzer and StockAnalyzerClip
+...
+```

--- a/.agents/skills/xcode-build-fixer/references/fix-patterns.md
+++ b/.agents/skills/xcode-build-fixer/references/fix-patterns.md
@@ -1,0 +1,290 @@
+# Fix Patterns
+
+Concrete before/after examples for each fix category. Reference this when applying approved changes to ensure consistency.
+
+## Build Settings Fixes
+
+### Debug Information Format (Debug)
+
+Before (`project.pbxproj`):
+```
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+```
+
+After:
+```
+DEBUG_INFORMATION_FORMAT = dwarf;
+```
+
+### Compilation Mode (Debug)
+
+Before:
+```
+SWIFT_COMPILATION_MODE = wholemodule;
+```
+
+After:
+```
+SWIFT_COMPILATION_MODE = singlefile;
+```
+
+### Enable Compilation Caching
+
+Before (setting absent or):
+```
+COMPILATION_CACHE_ENABLE_CACHING = NO;
+```
+
+After:
+```
+COMPILATION_CACHE_ENABLE_CACHING = YES;
+```
+
+### Enable Eager Linking (Debug)
+
+Before (setting absent):
+
+After:
+```
+EAGER_LINKING = YES;
+```
+
+## Script Phase Fixes
+
+### Add Configuration Guard
+
+Before:
+```bash
+# Upload dSYMs to crash reporter
+./scripts/upload-dsyms.sh
+```
+
+After:
+```bash
+# Upload dSYMs to crash reporter
+[[ "$CONFIGURATION" != "Release" ]] && exit 0
+./scripts/upload-dsyms.sh
+```
+
+### Add Input/Output Declarations
+
+When a script has no declared inputs or outputs, Xcode runs it on every build. Declare them in the build phase or use `.xcfilelist` files for long lists.
+
+Before (in Xcode build phase):
+```
+Input Files: (none)
+Output Files: (none)
+```
+
+After:
+```
+Input Files:
+  $(SRCROOT)/scripts/generate-constants.sh
+  $(SRCROOT)/Config/constants.json
+
+Output Files:
+  $(DERIVED_FILE_DIR)/GeneratedConstants.swift
+```
+
+## Source-Level Fixes
+
+### Add Explicit Type Annotations
+
+Before:
+```swift
+let result = items.map { $0.value }.filter { $0 > threshold }.reduce(0, +)
+```
+
+After:
+```swift
+let mapped: [Double] = items.map { $0.value }
+let filtered: [Double] = mapped.filter { $0 > threshold }
+let result: Double = filtered.reduce(0, +)
+```
+
+### Break Complex Expressions
+
+Before:
+```swift
+let config = try JSONDecoder().decode(
+    AppConfig.self,
+    from: Data(contentsOf: Bundle.main.url(forResource: "config", withExtension: "json")!)
+)
+```
+
+After:
+```swift
+let configURL: URL = Bundle.main.url(forResource: "config", withExtension: "json")!
+let configData: Data = try Data(contentsOf: configURL)
+let config: AppConfig = try JSONDecoder().decode(AppConfig.self, from: configData)
+```
+
+### Mark Classes Final
+
+Before:
+```swift
+class NetworkService {
+    func fetchData() async throws -> Data { ... }
+}
+```
+
+After:
+```swift
+final class NetworkService {
+    func fetchData() async throws -> Data { ... }
+}
+
+```
+
+Only apply when the class is not subclassed anywhere in the project. Search for `: NetworkService` and `class ... : NetworkService` before marking `final`.
+
+### Tighten Access Control
+
+Before:
+```swift
+class ViewModel {
+    var internalState: State = .idle
+    func processQueue() { ... }
+}
+```
+
+After:
+```swift
+class ViewModel {
+    private var internalState: State = .idle
+    private func processQueue() { ... }
+}
+```
+
+Apply `private` when the symbol is only used within the same declaration. Apply `fileprivate` when used within the same file but outside the declaration.
+
+### Extract SwiftUI Subviews
+
+Before:
+```swift
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            HStack {
+                Image(systemName: "person")
+                Text(user.name)
+                Spacer()
+                Button("Edit") { showEdit = true }
+            }
+            List(items) { item in
+                HStack {
+                    Text(item.title)
+                    Spacer()
+                    Text(item.subtitle)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+```
+
+After:
+```swift
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            UserHeaderView(user: user, showEdit: $showEdit)
+            ItemListView(items: items)
+        }
+    }
+}
+
+struct UserHeaderView: View {
+    let user: User
+    @Binding var showEdit: Bool
+
+    var body: some View {
+        HStack {
+            Image(systemName: "person")
+            Text(user.name)
+            Spacer()
+            Button("Edit") { showEdit = true }
+        }
+    }
+}
+
+struct ItemListView: View {
+    let items: [Item]
+
+    var body: some View {
+        List(items) { item in
+            ItemRowView(item: item)
+        }
+    }
+}
+
+struct ItemRowView: View {
+    let item: Item
+
+    var body: some View {
+        HStack {
+            Text(item.title)
+            Spacer()
+            Text(item.subtitle)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+```
+
+### Add Explicit Closure Return Types
+
+Before:
+```swift
+let handler = { value in
+    guard let result = try? process(value) else { return nil }
+    return result.transformed()
+}
+```
+
+After:
+```swift
+let handler: (InputType) -> OutputType? = { (value: InputType) -> OutputType? in
+    guard let result = try? process(value) else { return nil }
+    return result.transformed()
+}
+```
+
+## SPM Restructuring Fixes
+
+### Extract Shared Types to Lower-Layer Module
+
+Before (`Package.swift`):
+```swift
+.target(name: "FeatureA", dependencies: ["FeatureB"]),
+.target(name: "FeatureB", dependencies: ["FeatureA"]),
+```
+
+After:
+```swift
+.target(name: "SharedContracts", dependencies: []),
+.target(name: "FeatureA", dependencies: ["SharedContracts"]),
+.target(name: "FeatureB", dependencies: ["SharedContracts"]),
+```
+
+Move the shared protocols and types into `SharedContracts` so both features depend downward instead of on each other.
+
+### Extract Interface Module
+
+Before:
+```swift
+.target(name: "Networking", dependencies: ["Models"]),
+.target(name: "FeatureA", dependencies: ["Networking"]),
+.target(name: "FeatureB", dependencies: ["Networking"]),
+```
+
+After:
+```swift
+.target(name: "NetworkingInterface", dependencies: []),
+.target(name: "Networking", dependencies: ["NetworkingInterface", "Models"]),
+.target(name: "FeatureA", dependencies: ["NetworkingInterface"]),
+.target(name: "FeatureB", dependencies: ["NetworkingInterface"]),
+```
+
+Feature modules compile against the lightweight interface without waiting for the full implementation to build.

--- a/.agents/skills/xcode-build-fixer/references/recommendation-format.md
+++ b/.agents/skills/xcode-build-fixer/references/recommendation-format.md
@@ -1,0 +1,85 @@
+# Recommendation Format
+
+All optimization skills should report recommendations in a shared structure so the orchestrator can merge and prioritize them cleanly.
+
+## Required Fields
+
+Each recommendation should include:
+
+- `title`
+- `wait_time_impact` -- plain-language statement of expected wall-clock impact, e.g. "Expected to reduce your clean build by ~3s", "Reduces parallel compile work but unlikely to reduce build wait time", or "Impact on wait time is uncertain -- re-benchmark to confirm"
+- `actionability` -- classifies how fixable the issue is from the project (see values below)
+- `category`
+- `observed_evidence`
+- `estimated_impact`
+- `confidence`
+- `approval_required`
+- `benchmark_verification_status`
+
+### Actionability Values
+
+Every recommendation must include an `actionability` classification:
+
+- `repo-local` -- Fix lives entirely in project files, source code, or local configuration. The developer can apply it without side effects outside the repo.
+- `package-manager` -- Requires CocoaPods or SPM configuration changes that may have broad side effects (e.g., linkage mode, dependency restructuring). These should be benchmarked before and after.
+- `xcode-behavior` -- Observed cost is driven by Xcode internals and is not suppressible from the project. Report the finding for awareness but do not promise a fix.
+- `upstream` -- Requires changes in a third-party dependency or external tool. The developer cannot fix it locally.
+
+## Suggested Optional Fields
+
+- `scope`
+- `affected_files`
+- `affected_targets`
+- `affected_packages`
+- `implementation_notes`
+- `risk_level`
+
+## JSON Example
+
+```json
+{
+  "recommendations": [
+    {
+      "title": "Guard a release-only symbol upload script",
+      "wait_time_impact": "Expected to reduce your incremental build by approximately 6 seconds.",
+      "actionability": "repo-local",
+      "category": "project",
+      "observed_evidence": [
+        "Incremental builds spend 6.3 seconds in a run script phase.",
+        "The script runs for Debug builds even though the output is only needed in Release."
+      ],
+      "estimated_impact": "High incremental-build improvement",
+      "confidence": "High",
+      "approval_required": true,
+      "benchmark_verification_status": "Not yet verified",
+      "scope": "Target build phase",
+      "risk_level": "Low"
+    }
+  ]
+}
+```
+
+## Markdown Rendering Guidance
+
+When rendering for human review, preserve the same field order:
+
+1. title
+2. wait-time impact
+3. actionability
+4. observed evidence
+5. estimated impact
+6. confidence
+7. approval required
+8. benchmark verification status
+
+That makes it easier for the developer to approve or reject specific items quickly.
+
+## Verification Status Values
+
+Recommended values:
+
+- `Not yet verified`
+- `Queued for verification`
+- `Verified improvement`
+- `No measurable improvement`
+- `Inconclusive due to benchmark noise`

--- a/.agents/skills/xcode-build-fixer/scripts/benchmark_builds.py
+++ b/.agents/skills/xcode-build-fixer/scripts/benchmark_builds.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import platform
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark Xcode clean and incremental builds.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to the .xcworkspace file")
+    group.add_argument("--project", help="Path to the .xcodeproj file")
+    parser.add_argument("--scheme", required=True, help="Scheme to build")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--destination", help="xcodebuild destination string")
+    parser.add_argument("--derived-data-path", help="DerivedData path override")
+    parser.add_argument("--output-dir", default=".build-benchmark", help="Output directory for artifacts")
+    parser.add_argument("--repeats", type=int, default=3, help="Measured runs per build type")
+    parser.add_argument("--skip-warmup", action="store_true", help="Skip the validation build")
+    parser.add_argument(
+        "--touch-file",
+        help="Path to a source file to touch before each incremental build. "
+        "When provided, measures a real edit-rebuild loop instead of a zero-change build.",
+    )
+    parser.add_argument(
+        "--no-cached-clean",
+        action="store_true",
+        help="Skip cached clean builds even when COMPILATION_CACHE_ENABLE_CACHING is detected.",
+    )
+    parser.add_argument(
+        "--extra-arg",
+        action="append",
+        default=[],
+        help="Additional xcodebuild argument to append. Can be passed multiple times.",
+    )
+    return parser.parse_args()
+
+
+def command_base(args: argparse.Namespace) -> List[str]:
+    command = ["xcodebuild"]
+    if args.workspace:
+        command.extend(["-workspace", args.workspace])
+    if args.project:
+        command.extend(["-project", args.project])
+    command.extend(["-scheme", args.scheme, "-configuration", args.configuration])
+    if args.destination:
+        command.extend(["-destination", args.destination])
+    if args.derived_data_path:
+        command.extend(["-derivedDataPath", args.derived_data_path])
+    command.extend(args.extra_arg)
+    return command
+
+
+def shell_join(parts: List[str]) -> str:
+    return " ".join(subprocess.list2cmdline([part]) for part in parts)
+
+
+_TASK_COUNT_RE = re.compile(r"^(.+?)\s*\((\d+)\s+tasks?\)$")
+
+
+def _extract_task_count(name: str) -> tuple[str, Optional[int]]:
+    """Split 'Category (N tasks)' into ('Category', N)."""
+    match = _TASK_COUNT_RE.match(name)
+    if match:
+        return match.group(1).strip(), int(match.group(2))
+    return name, None
+
+
+def parse_timing_summary(output: str) -> List[Dict]:
+    categories: Dict[str, float] = {}
+    task_counts: Dict[str, Optional[int]] = {}
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        for suffix in (" seconds", " second", " sec"):
+            if not line.endswith(suffix):
+                continue
+            trimmed = line[: -len(suffix)]
+            if "|" in trimmed:
+                name_part, _, seconds_text = trimmed.rpartition("|")
+            else:
+                name_part, _, seconds_text = trimmed.rpartition(" ")
+            try:
+                seconds = float(seconds_text.strip())
+            except ValueError:
+                continue
+            cleaned_name = name_part.replace("  ", " ").strip(" -:")
+            if len(cleaned_name) < 3:
+                continue
+            base_name, count = _extract_task_count(cleaned_name)
+            categories[base_name] = categories.get(base_name, 0.0) + seconds
+            if count is not None:
+                task_counts[base_name] = (task_counts.get(base_name) or 0) + count
+            break
+    result: List[Dict] = []
+    for name, seconds in sorted(categories.items(), key=lambda item: item[1], reverse=True):
+        entry: Dict = {"name": name, "seconds": round(seconds, 3)}
+        if name in task_counts:
+            entry["task_count"] = task_counts[name]
+        result.append(entry)
+    return result
+
+
+def run_command(command: List[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(command, capture_output=True, text=True)
+
+
+def stats_for(runs: List[Dict[str, object]]) -> Dict[str, float]:
+    durations = [run["duration_seconds"] for run in runs if run.get("success")]
+    if not durations:
+        return {
+            "count": 0,
+            "min_seconds": 0.0,
+            "max_seconds": 0.0,
+            "median_seconds": 0.0,
+            "average_seconds": 0.0,
+        }
+    return {
+        "count": len(durations),
+        "min_seconds": round(min(durations), 3),
+        "max_seconds": round(max(durations), 3),
+        "median_seconds": round(statistics.median(durations), 3),
+        "average_seconds": round(statistics.fmean(durations), 3),
+    }
+
+
+def xcode_version() -> str:
+    result = run_command(["xcodebuild", "-version"])
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def detect_compilation_caching(base_command: List[str]) -> bool:
+    """Check whether COMPILATION_CACHE_ENABLE_CACHING is enabled in the resolved build settings."""
+    result = run_command([*base_command, "-showBuildSettings"])
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("COMPILATION_CACHE_ENABLE_CACHING") and "=" in stripped:
+            value = stripped.split("=", 1)[1].strip()
+            return value == "YES"
+    return False
+
+
+def measure_build(
+    base_command: List[str],
+    artifact_stem: str,
+    output_dir: Path,
+    build_type: str,
+    run_index: int,
+) -> Dict[str, object]:
+    build_command = [*base_command, "build", "-showBuildTimingSummary"]
+    started = time.perf_counter()
+    result = run_command(build_command)
+    elapsed = round(time.perf_counter() - started, 3)
+    log_path = output_dir / f"{artifact_stem}-{build_type}-{run_index}.log"
+    log_path.write_text(result.stdout + result.stderr)
+    return {
+        "id": f"{build_type}-{run_index}",
+        "build_type": build_type,
+        "duration_seconds": elapsed,
+        "success": result.returncode == 0,
+        "exit_code": result.returncode,
+        "command": shell_join(build_command),
+        "raw_log_path": str(log_path),
+        "timing_summary_categories": parse_timing_summary(result.stdout + result.stderr),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    artifact_stem = f"{timestamp}-{args.scheme.replace(' ', '-').lower()}"
+    base_command = command_base(args)
+
+    if not args.skip_warmup:
+        warmup = run_command([*base_command, "build"])
+        if warmup.returncode != 0:
+          sys.stderr.write(warmup.stdout + warmup.stderr)
+          return warmup.returncode
+        warmup_clean = run_command([*base_command, "clean"])
+        if warmup_clean.returncode != 0:
+            sys.stderr.write(warmup_clean.stdout + warmup_clean.stderr)
+            return warmup_clean.returncode
+        warmup_rebuild = run_command([*base_command, "build"])
+        if warmup_rebuild.returncode != 0:
+            sys.stderr.write(warmup_rebuild.stdout + warmup_rebuild.stderr)
+            return warmup_rebuild.returncode
+
+    runs: Dict[str, list] = {"clean": [], "incremental": []}
+
+    for index in range(1, args.repeats + 1):
+        clean_result = run_command([*base_command, "clean"])
+        clean_log_path = output_dir / f"{artifact_stem}-clean-prep-{index}.log"
+        clean_log_path.write_text(clean_result.stdout + clean_result.stderr)
+        if clean_result.returncode != 0:
+            sys.stderr.write(clean_result.stdout + clean_result.stderr)
+            return clean_result.returncode
+        runs["clean"].append(measure_build(base_command, artifact_stem, output_dir, "clean", index))
+
+    # --- Cached clean builds ---------------------------------------------------
+    # When COMPILATION_CACHE_ENABLE_CACHING is enabled, the compilation cache lives outside
+    # DerivedData and survives product deletion.  We measure "cached clean"
+    # builds by pointing DerivedData at a temp directory, warming the cache with
+    # one build, then deleting the DerivedData directory (but not the cache)
+    # before each measured rebuild.  This captures the realistic scenario:
+    # branch switching, pulling changes, or Clean Build Folder.
+    should_cached_clean = not args.no_cached_clean and detect_compilation_caching(base_command)
+    if should_cached_clean:
+        dd_path = Path(args.derived_data_path) if args.derived_data_path else Path(
+            tempfile.mkdtemp(prefix="xcode-bench-dd-")
+        )
+        cached_cmd = list(base_command)
+        if not args.derived_data_path:
+            cached_cmd.extend(["-derivedDataPath", str(dd_path)])
+
+        cache_warmup = run_command([*cached_cmd, "build"])
+        if cache_warmup.returncode != 0:
+            sys.stderr.write("Warning: cached clean warmup build failed, skipping cached clean benchmarks.\n")
+            sys.stderr.write(cache_warmup.stdout + cache_warmup.stderr)
+            should_cached_clean = False
+
+    if should_cached_clean:
+        runs["cached_clean"] = []
+        for index in range(1, args.repeats + 1):
+            shutil.rmtree(dd_path, ignore_errors=True)
+            runs["cached_clean"].append(
+                measure_build(cached_cmd, artifact_stem, output_dir, "cached-clean", index)
+            )
+        shutil.rmtree(dd_path, ignore_errors=True)
+
+    # --- Incremental / zero-change builds --------------------------------------
+    incremental_label = "incremental"
+    if args.touch_file:
+        touch_path = Path(args.touch_file)
+        if not touch_path.exists():
+            sys.stderr.write(f"--touch-file path does not exist: {touch_path}\n")
+            return 1
+        incremental_label = "incremental"
+    else:
+        incremental_label = "zero-change"
+
+    for index in range(1, args.repeats + 1):
+        if args.touch_file:
+            touch_path.touch()
+        runs["incremental"].append(
+            measure_build(base_command, artifact_stem, output_dir, incremental_label, index)
+        )
+
+    summary: Dict[str, object] = {
+        "clean": stats_for(runs["clean"]),
+        "incremental": stats_for(runs["incremental"]),
+    }
+    if "cached_clean" in runs:
+        summary["cached_clean"] = stats_for(runs["cached_clean"])
+
+    artifact = {
+        "schema_version": "1.2.0" if "cached_clean" in runs else "1.1.0",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "build": {
+            "entrypoint": "workspace" if args.workspace else "project",
+            "path": args.workspace or args.project,
+            "scheme": args.scheme,
+            "configuration": args.configuration,
+            "destination": args.destination or "",
+            "derived_data_path": args.derived_data_path or "",
+            "command": shell_join(base_command),
+        },
+        "environment": {
+            "host": platform.node(),
+            "macos_version": platform.platform(),
+            "xcode_version": xcode_version(),
+            "cwd": os.getcwd(),
+        },
+        "runs": runs,
+        "summary": summary,
+        "notes": [f"touch-file: {args.touch_file}"] if args.touch_file else [],
+    }
+
+    artifact_path = output_dir / f"{artifact_stem}.json"
+    artifact_path.write_text(json.dumps(artifact, indent=2) + "\n")
+
+    print(f"Saved benchmark artifact: {artifact_path}")
+    print(f"Clean median: {artifact['summary']['clean']['median_seconds']}s")
+    if "cached_clean" in artifact["summary"]:
+        print(f"Cached clean median: {artifact['summary']['cached_clean']['median_seconds']}s")
+    inc_label = "Incremental" if args.touch_file else "Zero-change"
+    print(f"{inc_label} median: {artifact['summary']['incremental']['median_seconds']}s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/xcode-build-orchestrator/SKILL.md
+++ b/.agents/skills/xcode-build-orchestrator/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: xcode-build-orchestrator
+description: Orchestrate Xcode build optimization by benchmarking first, running the specialist analysis skills, prioritizing findings, requesting explicit approval, delegating approved fixes to xcode-build-fixer, and re-benchmarking after changes. Use when a developer wants an end-to-end build optimization workflow, asks to speed up Xcode builds, wants a full build audit, or needs a recommend-first optimization pass covering compilation, project settings, and packages.
+---
+
+# Xcode Build Orchestrator
+
+Use this skill as the recommend-first entrypoint for end-to-end Xcode build optimization work.
+
+## Non-Negotiable Rules
+
+- Wall-clock build time (how long the developer waits) is the primary success metric. Every recommendation must state its expected impact on the developer's actual wait time.
+- Start in recommendation mode.
+- Benchmark before making changes.
+- Do not modify project files, source files, packages, or scripts without explicit developer approval.
+- Preserve the evidence trail for every recommendation.
+- Re-benchmark after approved changes and report the wall-clock delta.
+
+## Two-Phase Workflow
+
+The orchestration is designed as two distinct phases separated by developer review.
+
+### Phase 1 -- Analyze (recommend-only)
+
+Run this phase in agent mode because the agent needs to execute builds, run benchmark scripts, write benchmark artifacts, and generate the optimization report. However, treat Phase 1 as **recommend-only**: do not modify any project files, source files, packages, or build settings. The only files the agent creates during this phase are benchmark artifacts and the optimization plan inside `.build-benchmark/`.
+
+1. Collect the build target context: workspace or project, scheme, configuration, destination, and current pain point. When both `.xcworkspace` and `.xcodeproj` exist, prefer `.xcodeproj` unless the workspace contains sub-projects required for the build. Workspaces that reference external projects may fail if those projects are not checked out.
+2. Run `xcode-build-benchmark` to establish a baseline if no fresh benchmark exists. The benchmark script auto-detects `COMPILATION_CACHE_ENABLE_CACHING = YES` and includes cached clean builds that measure the realistic developer experience (warm cache). If the build fails to compile, check `git log` for a recent buildable commit. When working in a worktree, cherry-picking a targeted build fix from a feature branch is acceptable to reach a buildable state. If SPM packages reference gitignored directories in their `exclude:` paths (e.g., `__Snapshots__`), create those directories before building -- worktrees do not contain gitignored content and `xcodebuild -resolvePackageDependencies` will crash otherwise.
+3. Verify the benchmark artifact has non-empty `timing_summary_categories`. If empty, the timing summary parser may have failed -- re-parse the raw logs or inspect them manually. If `COMPILATION_CACHE_ENABLE_CACHING` is enabled, also verify the artifact includes `cached_clean` runs.
+   - **Benchmark confidence check**: For each build type (clean, cached clean, incremental), compare the min and max values. If the spread (max - min) exceeds 20% of the median, flag the benchmark as having high variance and recommend running additional repetitions (5+ runs) before drawing conclusions. High variance makes it difficult to distinguish real improvements from noise. After applying changes, only claim an improvement if the post-change median falls outside the baseline's min-max range.
+4. If incremental builds are the primary pain point and Xcode 16.4+ is available, recommend the developer enable **Task Backtraces** (Scheme Editor > Build tab > Build Debugging > "Task Backtraces"). This reveals why each task re-ran, which is critical for diagnosing unexpected replanning or input invalidation. Include any Task Backtrace evidence in the analysis.
+5. Determine whether compile tasks are likely blocking wall-clock progress or just consuming parallel CPU time. Compare the sum of all timing-summary category seconds against the wall-clock median: if the sum is 2x+ the median, most work is parallelized and compile hotspot fixes are unlikely to reduce wait time. If `SwiftCompile`, `CompileC`, `SwiftEmitModule`, or `Planning Swift module` dominate the timing summary **and** appear likely to be on the critical path, run `diagnose_compilation.py` to capture type-checking hotspots. If they are parallelized, still run diagnostics but label findings as "parallel efficiency improvements" rather than "build time improvements."
+6. Run the specialist analyses that fit the evidence by reading each skill's SKILL.md and applying its workflow:
+   - [`xcode-compilation-analyzer`](../xcode-compilation-analyzer/SKILL.md)
+   - [`xcode-project-analyzer`](../xcode-project-analyzer/SKILL.md)
+   - [`spm-build-analysis`](../spm-build-analysis/SKILL.md)
+7. Merge findings into a single prioritized improvement plan.
+8. Generate the markdown optimization report using `generate_optimization_report.py` and save it to `.build-benchmark/optimization-plan.md`. This report includes the build settings audit, timing analysis, prioritized recommendations, and an approval checklist.
+9. Stop and present the plan to the developer for review.
+
+The developer reviews `.build-benchmark/optimization-plan.md`, checks the approval boxes for the recommendations they want implemented, and then triggers phase 2.
+
+### Phase 2 -- Execute and verify (agent mode)
+
+Run this phase in agent mode after the developer has reviewed and approved recommendations from the plan. Delegate all implementation work to [`xcode-build-fixer`](../xcode-build-fixer/SKILL.md) by reading its SKILL.md and applying its workflow.
+
+10. Read `.build-benchmark/optimization-plan.md` and identify the approved items from the approval checklist.
+11. Hand off to `xcode-build-fixer` with the approved plan. The fixer applies each approved change, verifies compilation, and re-benchmarks.
+12. Append verification results to the optimization plan: post-change medians, absolute and percentage deltas, and confidence notes.
+13. Report before and after results, plus any remaining follow-up opportunities.
+
+## Prioritization Rules
+
+The goal is to reduce how long the developer waits for builds to finish.
+
+1. Identify the developer's primary pain (clean build, incremental build, or both) and the measured wall-clock median.
+2. Determine what is likely **blocking** wall-clock progress:
+   - If the sum of all timing-summary category seconds is 2x+ the wall-clock median, most work is parallelized. Compile hotspot fixes are unlikely to reduce wait time.
+   - If a single serial category (e.g. `PhaseScriptExecution`, `CompileAssetCatalog`, `CodeSign`) accounts for a large fraction of wall-clock, that is the real bottleneck.
+   - If `Planning Swift module` or `SwiftEmitModule` dominates incremental builds, the cause is likely invalidation or module size, not individual file compile speed.
+3. Rank recommendations by likely wall-time savings, not cumulative task reduction.
+4. Source-level compile fixes should not outrank project/graph/configuration fixes unless evidence suggests they are on the critical path.
+
+Prefer changes that are measurable, reversible, and low-risk.
+
+## Recommendation Impact Language
+
+Every recommendation presented to the developer must include one of these impact statements:
+
+- "Expected to reduce your [clean/incremental] build by approximately X seconds."
+- "Reduces parallel compile work but is unlikely to reduce your build wait time because other tasks take equally long."
+- "Impact on wait time is uncertain -- re-benchmark after applying to confirm."
+- "No wait-time improvement expected. The benefit is [deterministic builds / faster branch switching / reduced CI cost]."
+- For COMPILATION_CACHE_ENABLE_CACHING specifically: "Measured 5-14% faster clean builds across tested projects. The benefit compounds in real workflows where the cache persists between builds -- branch switching, pulling changes, and CI with persistent DerivedData."
+
+Never quote cumulative task-time savings as the headline impact. If a change reduces 5 seconds of parallel compile work but another equally long task still runs, the developer's wait time does not change.
+
+## Approval Gate
+
+Before implementing anything, present a short approval list that includes:
+
+- recommendation name
+- expected wait-time impact (using the impact language above)
+- evidence summary
+- affected files or settings
+- whether the change is low, medium, or high risk
+
+Wait for explicit developer approval.
+
+## Post-Approval Execution
+
+After approval, delegate to `xcode-build-fixer`:
+
+- the fixer implements only the approved items
+- changes are applied atomically and kept scoped
+- any deviations from the original recommendation plan are noted
+- the fixer re-benchmarks with the same benchmark contract
+
+## Final Report
+
+Lead with the wall-clock result in plain language, e.g.: "Your clean build now takes 82s (was 86s) -- 4s faster." Then include:
+
+- baseline clean and incremental wall-clock medians
+- post-change clean and incremental wall-clock medians
+- absolute and percentage wall-clock deltas
+- what changed
+- what was intentionally left unchanged
+- confidence notes if noise prevents a strong conclusion -- if benchmark variance is high (min-to-max spread exceeds 20% of median), say so explicitly rather than presenting noisy numbers as definitive improvements or regressions
+- if cumulative task metrics improved but wall-clock did not, say plainly: "Compiler workload decreased but build wait time did not improve. This is expected when Xcode runs these tasks in parallel with other equally long work."
+- a ready-to-paste community results row and a link to open a PR (see the report template)
+
+## Preferred Command Paths
+
+### Benchmark
+
+```bash
+python3 scripts/benchmark_builds.py \
+  --project App.xcodeproj \
+  --scheme MyApp \
+  --configuration Debug \
+  --destination "platform=iOS Simulator,name=iPhone 16" \
+  --output-dir .build-benchmark
+```
+
+For macOS apps use `--destination "platform=macOS"`. For watchOS use `--destination "platform=watchOS Simulator,name=Apple Watch Series 10"`. For tvOS use `--destination "platform=tvOS Simulator,name=Apple TV"`. Omit `--destination` to use the scheme's default.
+
+To measure real incremental builds (file-touched rebuild) instead of zero-change builds, add `--touch-file path/to/SomeFile.swift`.
+
+### Compilation Diagnostics
+
+```bash
+python3 scripts/diagnose_compilation.py \
+  --project App.xcodeproj \
+  --scheme MyApp \
+  --configuration Debug \
+  --destination "platform=iOS Simulator,name=iPhone 16" \
+  --threshold 100 \
+  --output-dir .build-benchmark
+```
+
+### Optimization Report
+
+```bash
+python3 scripts/generate_optimization_report.py \
+  --benchmark .build-benchmark/<artifact>.json \
+  --project-path App.xcodeproj \
+  --diagnostics .build-benchmark/<diagnostics>.json \
+  --output .build-benchmark/optimization-plan.md
+```
+
+## Additional Resources
+
+- For the report template, see [references/orchestration-report-template.md](references/orchestration-report-template.md)
+- For benchmark artifact requirements, see [references/benchmark-artifacts.md](references/benchmark-artifacts.md)
+- For the recommendation format, see [references/recommendation-format.md](references/recommendation-format.md)
+- For build settings best practices, see [references/build-settings-best-practices.md](references/build-settings-best-practices.md)

--- a/.agents/skills/xcode-build-orchestrator/references/benchmark-artifacts.md
+++ b/.agents/skills/xcode-build-orchestrator/references/benchmark-artifacts.md
@@ -1,0 +1,94 @@
+# Benchmark Artifacts
+
+All skills in this repository should treat `.build-benchmark/` as the canonical location for measured build evidence.
+
+## Goals
+
+- Keep build measurements reproducible.
+- Make clean and incremental build data easy to compare.
+- Preserve enough context for later specialist analysis without rerunning the benchmark.
+
+## Wall-Clock vs Cumulative Task Time
+
+The `duration_seconds` field on each run and the `median_seconds` in the summary represent **wall-clock time** -- how long the developer actually waits. This is the primary success metric.
+
+The `timing_summary_categories` are **aggregated task times** parsed from Xcode's Build Timing Summary. Because Xcode runs many tasks in parallel across CPU cores, these totals typically exceed the wall-clock duration. A large cumulative `SwiftCompile` value is diagnostic evidence of compiler workload, not proof that compilation is blocking the build. Always compare category totals against the wall-clock median before concluding that a category is a bottleneck.
+
+## File Layout
+
+Recommended outputs:
+
+- `.build-benchmark/<timestamp>-<scheme>.json`
+- `.build-benchmark/<timestamp>-<scheme>-clean-1.log`
+- `.build-benchmark/<timestamp>-<scheme>-clean-2.log`
+- `.build-benchmark/<timestamp>-<scheme>-clean-3.log`
+- `.build-benchmark/<timestamp>-<scheme>-cached-clean-1.log` (when COMPILATION_CACHE_ENABLE_CACHING is enabled)
+- `.build-benchmark/<timestamp>-<scheme>-cached-clean-2.log`
+- `.build-benchmark/<timestamp>-<scheme>-cached-clean-3.log`
+- `.build-benchmark/<timestamp>-<scheme>-incremental-1.log`
+- `.build-benchmark/<timestamp>-<scheme>-incremental-2.log`
+- `.build-benchmark/<timestamp>-<scheme>-incremental-3.log`
+
+Use an ISO-like UTC timestamp without spaces so the files sort naturally.
+
+## Artifact Requirements
+
+Each JSON artifact should include:
+
+- schema version
+- creation timestamp
+- project context
+- environment details when available
+- the normalized build command
+- separate `clean` and `incremental` run arrays
+- summary statistics for each build type
+- parsed timing-summary categories
+- free-form notes for caveats or noise
+
+## Clean, Cached Clean, And Incremental Separation
+
+Do not merge different build type measurements into a single list. They answer different questions:
+
+- **Clean builds** show full build-system, package, and module setup cost with a cold compilation cache.
+- **Cached clean builds** show clean build cost when the compilation cache is warm. This is the realistic scenario for branch switching, pulling changes, or Clean Build Folder. Only present when `COMPILATION_CACHE_ENABLE_CACHING = YES` is detected.
+- **Incremental builds** show edit-loop productivity and script or cache invalidation problems.
+
+## Raw Logs
+
+Store raw `xcodebuild` output beside the JSON artifact whenever possible. That allows later skills to:
+
+- re-parse timing summaries
+- inspect failed builds
+- search for long type-check warnings
+- correlate build-system phases with recommendations
+
+## Measurement Caveats
+
+### COMPILATION_CACHE_ENABLE_CACHING
+
+`COMPILATION_CACHE_ENABLE_CACHING = YES` stores compiled artifacts in a system-managed cache outside DerivedData so that repeated compilations of identical inputs are served from cache. The standard clean-build benchmark (`xcodebuild clean` between runs) may add overhead from cache population without showing the corresponding cache-hit benefit.
+
+The benchmark script automatically detects `COMPILATION_CACHE_ENABLE_CACHING = YES` and runs a **cached clean** benchmark phase. This phase:
+
+1. Builds once to warm the compilation cache.
+2. Deletes DerivedData (but not the compilation cache) before each measured run.
+3. Rebuilds, measuring the cache-hit clean build time.
+
+The cached clean metric captures the realistic developer experience: branch switching, pulling changes, and Clean Build Folder. Use the cached clean median as the primary comparison metric when evaluating `COMPILATION_CACHE_ENABLE_CACHING` impact.
+
+To skip this phase, pass `--no-cached-clean`.
+
+### First-Run Variance
+
+The first clean build after the warmup cycle often runs 20-40% slower than subsequent clean builds due to cold OS-level caches (disk I/O, dynamic linker cache, etc.). The benchmark script mitigates this by running a warmup clean+build cycle before measured runs. If variance between the first and later clean runs is still high, prefer the median or min over the mean, and note the variance in the artifact's `notes` field.
+
+## Shared Consumer Expectations
+
+Any skill reading a benchmark artifact should be able to identify:
+
+- what was measured
+- how it was measured
+- whether the run succeeded
+- whether the results are stable enough to compare
+
+For the authoritative field-level schema, see the `build-benchmark.schema.json` bundled with the xcode-build-benchmark skill.

--- a/.agents/skills/xcode-build-orchestrator/references/build-settings-best-practices.md
+++ b/.agents/skills/xcode-build-orchestrator/references/build-settings-best-practices.md
@@ -1,0 +1,216 @@
+# Build Settings Best Practices
+
+This reference lists Xcode build settings that affect build performance. Use it to audit a project and produce a pass/fail checklist.
+
+The scope is strictly **build performance**. Do not flag language-migration settings like `SWIFT_STRICT_CONCURRENCY` or `SWIFT_UPCOMING_FEATURE_*` -- those are developer adoption choices unrelated to build speed.
+
+## How To Read This Reference
+
+Each setting includes:
+
+- **Setting name** and the Xcode build-settings key
+- **Recommended value** for Debug and Release
+- **Why it matters** for build time
+- **Risk** of changing it
+
+Use checkmark and cross indicators when reporting:
+
+- `[x]` -- setting matches the recommended value
+- `[ ]` -- setting does not match; include the actual value and the expected value
+
+## Debug Configuration
+
+These settings optimize for fast iteration during development.
+
+### Compilation Mode
+
+- **Key:** `SWIFT_COMPILATION_MODE`
+- **Recommended:** `singlefile` (Xcode UI: "Incremental"; or unset -- Xcode defaults to singlefile for Debug)
+- **Why:** Single-file mode recompiles only changed files. `wholemodule` recompiles the entire target on every change.
+- **Risk:** Low
+
+### Swift Optimization Level
+
+- **Key:** `SWIFT_OPTIMIZATION_LEVEL`
+- **Recommended:** `-Onone`
+- **Why:** Optimization passes add significant compile time. Debug builds do not benefit from runtime speed improvements.
+- **Risk:** Low
+
+### GCC Optimization Level
+
+- **Key:** `GCC_OPTIMIZATION_LEVEL`
+- **Recommended:** `0`
+- **Why:** Same rationale as Swift optimization level, but for C/C++/Objective-C sources.
+- **Risk:** Low
+
+### Build Active Architecture Only
+
+- **Key:** `ONLY_ACTIVE_ARCH` (`BUILD_ACTIVE_ARCHITECTURE_ONLY`)
+- **Recommended:** `YES`
+- **Why:** Building all architectures doubles or triples compile and link time for no debug benefit.
+- **Risk:** Low
+
+### Debug Information Format
+
+- **Key:** `DEBUG_INFORMATION_FORMAT`
+- **Recommended:** `dwarf`
+- **Why:** `dwarf-with-dsym` generates a separate dSYM bundle which adds overhead. Plain `dwarf` embeds debug info directly in the binary, which is sufficient for local debugging.
+- **Risk:** Low
+
+### Enable Testability
+
+- **Key:** `ENABLE_TESTABILITY`
+- **Recommended:** `YES`
+- **Why:** Required for `@testable import`. Adds minor overhead by exporting internal symbols, but this is expected during development.
+- **Risk:** Low
+
+### Active Compilation Conditions
+
+- **Key:** `SWIFT_ACTIVE_COMPILATION_CONDITIONS`
+- **Recommended:** Should include `DEBUG`
+- **Why:** Guards conditional compilation blocks (e.g., `#if DEBUG`) and ensures debug-only code paths are included.
+- **Risk:** Low
+
+### Eager Linking
+
+- **Key:** `EAGER_LINKING`
+- **Recommended:** `YES`
+- **Why:** Allows the linker to start work before all compilation tasks finish, reducing wall-clock build time. Particularly effective for Debug builds where link time is a meaningful fraction of total build time.
+- **Risk:** Low
+
+## Release Configuration
+
+These settings optimize for production builds.
+
+### Compilation Mode
+
+- **Key:** `SWIFT_COMPILATION_MODE`
+- **Recommended:** `wholemodule`
+- **Why:** Whole-module optimization produces faster runtime code. Build time is secondary for release.
+- **Risk:** Low
+
+### Swift Optimization Level
+
+- **Key:** `SWIFT_OPTIMIZATION_LEVEL`
+- **Recommended:** `-O` or `-Osize`
+- **Why:** Produces optimized binaries. `-Osize` trades some speed for smaller binary size.
+- **Risk:** Low
+
+### GCC Optimization Level
+
+- **Key:** `GCC_OPTIMIZATION_LEVEL`
+- **Recommended:** `s`
+- **Why:** Optimizes C/C++/Objective-C for size, matching the typical release expectation.
+- **Risk:** Low
+
+### Build Active Architecture Only
+
+- **Key:** `ONLY_ACTIVE_ARCH`
+- **Recommended:** `NO`
+- **Why:** Release builds must include all supported architectures for distribution.
+- **Risk:** Low
+
+### Debug Information Format
+
+- **Key:** `DEBUG_INFORMATION_FORMAT`
+- **Recommended:** `dwarf-with-dsym`
+- **Why:** dSYM bundles are required for crash symbolication in production.
+- **Risk:** Low
+
+### Enable Testability
+
+- **Key:** `ENABLE_TESTABILITY`
+- **Recommended:** `NO`
+- **Why:** Removes internal-symbol export overhead from release builds. Testing should use Debug configuration.
+- **Risk:** Low
+
+## General (All Configurations)
+
+### Compilation Caching
+
+- **Key:** `COMPILATION_CACHE_ENABLE_CACHING`
+- **Recommended:** `YES`
+- **Why:** Caches compilation results for Swift and C-family sources so repeated compilations of the same inputs are served from cache. The biggest wins come from branch switching and clean builds where source files are recompiled unchanged. This is an opt-in feature. The umbrella setting controls both `SWIFT_ENABLE_COMPILE_CACHE` and `CLANG_ENABLE_COMPILE_CACHE` under the hood; those can be toggled independently if needed.
+- **Measurement:** Measured 5-14% faster clean builds across tested projects (87 to 1,991 Swift files). The benefit compounds in real developer workflows where the cache persists between builds -- branch switching, pulling changes, and CI with persistent DerivedData -- though the exact savings depend on how many files change between builds.
+- **Risk:** Low -- can also be enabled via per-user project settings so it does not need to be committed to the shared project file.
+
+### Integrated Swift Driver
+
+- **Key:** `SWIFT_USE_INTEGRATED_DRIVER`
+- **Recommended:** `YES`
+- **Why:** Uses the integrated Swift driver which runs inside the build system process, eliminating inter-process overhead for compilation scheduling. Enabled by default in modern Xcode but worth verifying in migrated projects.
+- **Risk:** Low
+
+### Clang Module Compilation
+
+- **Key:** `CLANG_ENABLE_MODULES`
+- **Recommended:** `YES`
+- **Why:** Enables Clang module compilation for C/Objective-C sources, caching module maps on disk instead of reprocessing headers on every import. Eliminates redundant header parsing across translation units.
+- **Risk:** Low
+
+### Explicit Module Builds
+
+- **Key:** `SWIFT_ENABLE_EXPLICIT_MODULES` (C/ObjC enabled by default in Xcode 16+; for Swift use `_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES`)
+- **Recommended:** Evaluate per-project
+- **Why:** Makes module compilation visible to the build system as discrete tasks, improving parallelism and scheduling. Reduces redundant module rebuilds by making dependency edges explicit. Some projects see regressions due to the overhead of dependency scanning, so benchmark before and after enabling.
+- **Risk:** Medium -- test thoroughly; currently experimental for Swift targets.
+
+## Cross-Target Consistency
+
+These checks find settings differences between targets that cause redundant build work.
+
+### Project-Level vs Target-Level Overrides
+
+Build-affecting settings should be set at the project level unless a target has a specific reason to override. Unnecessary per-target overrides cause confusion and can silently create module variants.
+
+Settings to check for project-level consistency:
+
+- `SWIFT_COMPILATION_MODE`
+- `SWIFT_OPTIMIZATION_LEVEL`
+- `ONLY_ACTIVE_ARCH`
+- `DEBUG_INFORMATION_FORMAT`
+
+### Module Variant Duplication
+
+When multiple targets import the same SPM package but compile with different Swift compiler options, the build system produces separate module variants for each combination. This inflates `SwiftEmitModule` task counts.
+
+Check for drift in:
+
+- `SWIFT_OPTIMIZATION_LEVEL`
+- `SWIFT_COMPILATION_MODE`
+- `OTHER_SWIFT_FLAGS`
+- Target-level build settings that override project defaults
+
+### Out of Scope
+
+Do **not** flag the following as build-performance issues:
+
+- `SWIFT_STRICT_CONCURRENCY` -- language migration choice
+- `SWIFT_UPCOMING_FEATURE_*` -- language migration choice
+- `SWIFT_APPROACHABLE_CONCURRENCY` -- language migration choice
+- `SWIFT_ACTIVE_COMPILATION_CONDITIONS` values beyond `DEBUG` (e.g., `WIDGETS`, `APPCLIP`) -- intentional per-target customization
+
+## Checklist Output Format
+
+When reporting results, use this structure:
+
+```markdown
+### Debug Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `singlefile` (recommended: `singlefile`)
+- [ ] `DEBUG_INFORMATION_FORMAT`: `dwarf-with-dsym` (recommended: `dwarf`)
+- [x] `SWIFT_OPTIMIZATION_LEVEL`: `-Onone` (recommended: `-Onone`)
+...
+
+### Release Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `wholemodule` (recommended: `wholemodule`)
+...
+
+### General (All Configurations)
+- [ ] `COMPILATION_CACHE_ENABLE_CACHING`: `NO` (recommended: `YES`)
+...
+
+### Cross-Target Consistency
+- [x] All targets inherit `SWIFT_OPTIMIZATION_LEVEL` from project level
+- [ ] `OTHER_SWIFT_FLAGS` differs between Stock Analyzer and StockAnalyzerClip
+...
+```

--- a/.agents/skills/xcode-build-orchestrator/references/orchestration-report-template.md
+++ b/.agents/skills/xcode-build-orchestrator/references/orchestration-report-template.md
@@ -1,0 +1,143 @@
+# Orchestration Report Template
+
+Use this structure when the orchestrator consolidates benchmark evidence and specialist findings. The `generate_optimization_report.py` script produces this format automatically when given the benchmark and diagnostics artifacts.
+
+```markdown
+# Xcode Build Optimization Plan
+
+## Project Context
+- **Project:** `App.xcodeproj`
+- **Scheme:** `MyApp`
+- **Configuration:** `Debug`
+- **Destination:** `platform=iOS Simulator,name=iPhone 16`
+- **Xcode:** Xcode 26.x
+- **Date:** 2026-01-01T00:00:00Z
+- **Benchmark artifact:** `.build-benchmark/<timestamp>-<scheme>.json`
+
+## Baseline Benchmarks
+
+| Metric | Clean | Cached Clean | Zero-Change |
+|--------|-------|-------------|-------------|
+| Median | 0.000s | 0.000s | 0.000s |
+| Min | 0.000s | 0.000s | 0.000s |
+| Max | 0.000s | 0.000s | 0.000s |
+| Runs | 3 | 3 | 3 |
+
+> **Cached Clean** = clean build with a warm compilation cache. This is the realistic scenario for branch switching, pulling changes, or Clean Build Folder. Only present when `COMPILATION_CACHE_ENABLE_CACHING = YES` is detected. "Zero-Change" = rebuild with no edits (measures fixed overhead). Use `--touch-file` in the benchmark script to measure true incremental builds where a source file is modified.
+
+### Clean Build Timing Summary
+
+> **Note:** These are aggregated task times across all CPU cores. Because Xcode runs many tasks in parallel, these totals typically exceed the actual build wait time shown above. A large number here does not mean it is blocking your build.
+
+| Category | Tasks | Seconds |
+|----------|------:|--------:|
+| SwiftCompile | 325 | 271.245s |
+| SwiftEmitModule | 30 | 23.625s |
+| ... | ... | ... |
+
+## Build Settings Audit
+
+### Debug Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `(unset)` (recommended: `singlefile`)
+- [x] `SWIFT_OPTIMIZATION_LEVEL`: `-Onone` (recommended: `-Onone`)
+- [x] `GCC_OPTIMIZATION_LEVEL`: `0` (recommended: `0`)
+- [x] `ONLY_ACTIVE_ARCH`: `YES` (recommended: `YES`)
+- [x] `DEBUG_INFORMATION_FORMAT`: `dwarf` (recommended: `dwarf`)
+- [x] `ENABLE_TESTABILITY`: `YES` (recommended: `YES`)
+- [x] `EAGER_LINKING`: `YES` (recommended: `YES`)
+
+### General (All Configurations)
+- [x] `COMPILATION_CACHE_ENABLE_CACHING`: `YES` (recommended: `YES`)
+- [x] `SWIFT_USE_INTEGRATED_DRIVER`: `YES` (recommended: `YES`)
+- [x] `CLANG_ENABLE_MODULES`: `YES` (recommended: `YES`)
+
+### Release Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `wholemodule` (recommended: `wholemodule`)
+- [x] `SWIFT_OPTIMIZATION_LEVEL`: `-O` (recommended: `-O`)
+- ...
+
+### Cross-Target Consistency
+- [x] `SWIFT_COMPILATION_MODE` is consistent across all targets
+- [ ] `OTHER_SWIFT_FLAGS` has target-level overrides: ...
+
+## Compilation Diagnostics
+
+| Duration | Kind | File | Line | Name |
+|---------:|------|------|-----:|------|
+| 150ms | function-body | MyView.swift | 42 | body |
+| ... | ... | ... | ... | ... |
+
+## Prioritized Recommendations
+
+### 1. Recommendation title
+**Wait-Time Impact:** Expected to reduce your clean build by approximately 3 seconds.
+**Category:** project
+**Evidence:** ...
+**Impact:** High
+**Confidence:** High
+**Risk:** Low
+
+## Approval Checklist
+- [ ] **1. Recommendation title** -- Wait-Time Impact: ~3s clean build reduction | Risk: Low
+- [ ] **2. Another recommendation** -- Wait-Time Impact: Uncertain, re-benchmark to confirm | Risk: Low
+
+## Next Steps
+
+After implementing approved changes, re-benchmark with the same inputs:
+
+...
+
+Compare the new wall-clock medians against the baseline. Report results as:
+"Your [clean/incremental] build now takes X.Xs (was Y.Ys) -- Z.Zs faster/slower."
+
+## Execution Report (post-approval)
+
+### Baseline
+- Clean build median: X.Xs
+- Cached clean build median: X.Xs (if applicable)
+- Incremental build median: X.Xs
+
+### Changes Applied
+
+| # | Change | Actionability | Measured Result | Status |
+|---|--------|---------------|-----------------|--------|
+| 1 | Description of change | repo-local | Clean: X.Xs→Y.Ys, Incr: X.Xs→Y.Ys | Kept / Reverted / Blocked |
+| 2 | ... | ... | ... | ... |
+
+Status values: `Kept`, `Kept (best practice)`, `Reverted`, `Blocked`, `No improvement`
+
+### Final Cumulative Result
+- Post-change clean build: X.Xs (was Y.Ys) -- Z.Zs faster/slower
+- Post-change cached clean build: X.Xs (was Y.Ys) -- Z.Zs faster/slower (when COMPILATION_CACHE_ENABLE_CACHING enabled)
+- Post-change incremental build: X.Xs (was Y.Ys) -- Z.Zs faster/slower
+- **Net result:** Faster / Slower / Unchanged
+- If cumulative task metrics improved but wall-clock did not: "Compiler workload decreased but build wait time did not improve. This is expected when Xcode runs these tasks in parallel with other equally long work."
+- If standard clean builds are slower but cached clean builds are faster: "Standard clean builds show overhead from compilation cache population. Cached clean builds (the realistic developer workflow) are faster, confirming the net benefit."
+
+### Blocked or Non-Actionable Findings
+- Finding: reason it could not be addressed from the repo
+
+## Remaining follow-up ideas
+- Item:
+- Why it was deferred:
+
+## Share your results
+
+Add your improvement to the community results table by opening a pull request.
+Copy the row below and append it to the table in README.md:
+
+| <project-name> | X.Xs → X.Xs (-X.Xs / X% faster) | X.Xs → X.Xs (-X.Xs / X% faster) |
+
+Open a PR: https://github.com/AvdLee/Xcode-Build-Optimization-Agent-Skill/edit/main/README.md
+```
+
+## Usage Notes
+
+- Keep approval-required items explicit.
+- Do not imply that an unapproved recommendation was applied.
+- If results are noisy, say that the verification is inconclusive instead of overstating success.
+- The Build Settings Audit scope is strictly build performance. Do not flag language-migration settings like `SWIFT_STRICT_CONCURRENCY` or `SWIFT_UPCOMING_FEATURE_*`.
+- The Compilation Diagnostics section is populated by `diagnose_compilation.py`. If not run, note that it was skipped.
+- `COMPILATION_CACHE_ENABLE_CACHING` has been measured at 5-14% faster clean builds across tested projects. The benefit compounds in real developer workflows (branch switching, pulling changes, CI with persistent DerivedData). The benchmark script auto-detects this setting and runs a cached clean phase for validation.
+- When recommending SPM version pins, verify that tagged versions exist (`git ls-remote --tags`) before suggesting a pin-to-tag change. If no tags exist, recommend pinning to a commit revision hash.
+- Before including a local package in a build-time recommendation, verify it is referenced in `project.pbxproj` via `XCLocalSwiftPackageReference`. Packages that exist on disk but are not linked do not affect build time.

--- a/.agents/skills/xcode-build-orchestrator/references/recommendation-format.md
+++ b/.agents/skills/xcode-build-orchestrator/references/recommendation-format.md
@@ -1,0 +1,85 @@
+# Recommendation Format
+
+All optimization skills should report recommendations in a shared structure so the orchestrator can merge and prioritize them cleanly.
+
+## Required Fields
+
+Each recommendation should include:
+
+- `title`
+- `wait_time_impact` -- plain-language statement of expected wall-clock impact, e.g. "Expected to reduce your clean build by ~3s", "Reduces parallel compile work but unlikely to reduce build wait time", or "Impact on wait time is uncertain -- re-benchmark to confirm"
+- `actionability` -- classifies how fixable the issue is from the project (see values below)
+- `category`
+- `observed_evidence`
+- `estimated_impact`
+- `confidence`
+- `approval_required`
+- `benchmark_verification_status`
+
+### Actionability Values
+
+Every recommendation must include an `actionability` classification:
+
+- `repo-local` -- Fix lives entirely in project files, source code, or local configuration. The developer can apply it without side effects outside the repo.
+- `package-manager` -- Requires CocoaPods or SPM configuration changes that may have broad side effects (e.g., linkage mode, dependency restructuring). These should be benchmarked before and after.
+- `xcode-behavior` -- Observed cost is driven by Xcode internals and is not suppressible from the project. Report the finding for awareness but do not promise a fix.
+- `upstream` -- Requires changes in a third-party dependency or external tool. The developer cannot fix it locally.
+
+## Suggested Optional Fields
+
+- `scope`
+- `affected_files`
+- `affected_targets`
+- `affected_packages`
+- `implementation_notes`
+- `risk_level`
+
+## JSON Example
+
+```json
+{
+  "recommendations": [
+    {
+      "title": "Guard a release-only symbol upload script",
+      "wait_time_impact": "Expected to reduce your incremental build by approximately 6 seconds.",
+      "actionability": "repo-local",
+      "category": "project",
+      "observed_evidence": [
+        "Incremental builds spend 6.3 seconds in a run script phase.",
+        "The script runs for Debug builds even though the output is only needed in Release."
+      ],
+      "estimated_impact": "High incremental-build improvement",
+      "confidence": "High",
+      "approval_required": true,
+      "benchmark_verification_status": "Not yet verified",
+      "scope": "Target build phase",
+      "risk_level": "Low"
+    }
+  ]
+}
+```
+
+## Markdown Rendering Guidance
+
+When rendering for human review, preserve the same field order:
+
+1. title
+2. wait-time impact
+3. actionability
+4. observed evidence
+5. estimated impact
+6. confidence
+7. approval required
+8. benchmark verification status
+
+That makes it easier for the developer to approve or reject specific items quickly.
+
+## Verification Status Values
+
+Recommended values:
+
+- `Not yet verified`
+- `Queued for verification`
+- `Verified improvement`
+- `No measurable improvement`
+- `Inconclusive due to benchmark noise`

--- a/.agents/skills/xcode-build-orchestrator/scripts/benchmark_builds.py
+++ b/.agents/skills/xcode-build-orchestrator/scripts/benchmark_builds.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import platform
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark Xcode clean and incremental builds.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to the .xcworkspace file")
+    group.add_argument("--project", help="Path to the .xcodeproj file")
+    parser.add_argument("--scheme", required=True, help="Scheme to build")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--destination", help="xcodebuild destination string")
+    parser.add_argument("--derived-data-path", help="DerivedData path override")
+    parser.add_argument("--output-dir", default=".build-benchmark", help="Output directory for artifacts")
+    parser.add_argument("--repeats", type=int, default=3, help="Measured runs per build type")
+    parser.add_argument("--skip-warmup", action="store_true", help="Skip the validation build")
+    parser.add_argument(
+        "--touch-file",
+        help="Path to a source file to touch before each incremental build. "
+        "When provided, measures a real edit-rebuild loop instead of a zero-change build.",
+    )
+    parser.add_argument(
+        "--no-cached-clean",
+        action="store_true",
+        help="Skip cached clean builds even when COMPILATION_CACHE_ENABLE_CACHING is detected.",
+    )
+    parser.add_argument(
+        "--extra-arg",
+        action="append",
+        default=[],
+        help="Additional xcodebuild argument to append. Can be passed multiple times.",
+    )
+    return parser.parse_args()
+
+
+def command_base(args: argparse.Namespace) -> List[str]:
+    command = ["xcodebuild"]
+    if args.workspace:
+        command.extend(["-workspace", args.workspace])
+    if args.project:
+        command.extend(["-project", args.project])
+    command.extend(["-scheme", args.scheme, "-configuration", args.configuration])
+    if args.destination:
+        command.extend(["-destination", args.destination])
+    if args.derived_data_path:
+        command.extend(["-derivedDataPath", args.derived_data_path])
+    command.extend(args.extra_arg)
+    return command
+
+
+def shell_join(parts: List[str]) -> str:
+    return " ".join(subprocess.list2cmdline([part]) for part in parts)
+
+
+_TASK_COUNT_RE = re.compile(r"^(.+?)\s*\((\d+)\s+tasks?\)$")
+
+
+def _extract_task_count(name: str) -> tuple[str, Optional[int]]:
+    """Split 'Category (N tasks)' into ('Category', N)."""
+    match = _TASK_COUNT_RE.match(name)
+    if match:
+        return match.group(1).strip(), int(match.group(2))
+    return name, None
+
+
+def parse_timing_summary(output: str) -> List[Dict]:
+    categories: Dict[str, float] = {}
+    task_counts: Dict[str, Optional[int]] = {}
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        for suffix in (" seconds", " second", " sec"):
+            if not line.endswith(suffix):
+                continue
+            trimmed = line[: -len(suffix)]
+            if "|" in trimmed:
+                name_part, _, seconds_text = trimmed.rpartition("|")
+            else:
+                name_part, _, seconds_text = trimmed.rpartition(" ")
+            try:
+                seconds = float(seconds_text.strip())
+            except ValueError:
+                continue
+            cleaned_name = name_part.replace("  ", " ").strip(" -:")
+            if len(cleaned_name) < 3:
+                continue
+            base_name, count = _extract_task_count(cleaned_name)
+            categories[base_name] = categories.get(base_name, 0.0) + seconds
+            if count is not None:
+                task_counts[base_name] = (task_counts.get(base_name) or 0) + count
+            break
+    result: List[Dict] = []
+    for name, seconds in sorted(categories.items(), key=lambda item: item[1], reverse=True):
+        entry: Dict = {"name": name, "seconds": round(seconds, 3)}
+        if name in task_counts:
+            entry["task_count"] = task_counts[name]
+        result.append(entry)
+    return result
+
+
+def run_command(command: List[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(command, capture_output=True, text=True)
+
+
+def stats_for(runs: List[Dict[str, object]]) -> Dict[str, float]:
+    durations = [run["duration_seconds"] for run in runs if run.get("success")]
+    if not durations:
+        return {
+            "count": 0,
+            "min_seconds": 0.0,
+            "max_seconds": 0.0,
+            "median_seconds": 0.0,
+            "average_seconds": 0.0,
+        }
+    return {
+        "count": len(durations),
+        "min_seconds": round(min(durations), 3),
+        "max_seconds": round(max(durations), 3),
+        "median_seconds": round(statistics.median(durations), 3),
+        "average_seconds": round(statistics.fmean(durations), 3),
+    }
+
+
+def xcode_version() -> str:
+    result = run_command(["xcodebuild", "-version"])
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def detect_compilation_caching(base_command: List[str]) -> bool:
+    """Check whether COMPILATION_CACHE_ENABLE_CACHING is enabled in the resolved build settings."""
+    result = run_command([*base_command, "-showBuildSettings"])
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("COMPILATION_CACHE_ENABLE_CACHING") and "=" in stripped:
+            value = stripped.split("=", 1)[1].strip()
+            return value == "YES"
+    return False
+
+
+def measure_build(
+    base_command: List[str],
+    artifact_stem: str,
+    output_dir: Path,
+    build_type: str,
+    run_index: int,
+) -> Dict[str, object]:
+    build_command = [*base_command, "build", "-showBuildTimingSummary"]
+    started = time.perf_counter()
+    result = run_command(build_command)
+    elapsed = round(time.perf_counter() - started, 3)
+    log_path = output_dir / f"{artifact_stem}-{build_type}-{run_index}.log"
+    log_path.write_text(result.stdout + result.stderr)
+    return {
+        "id": f"{build_type}-{run_index}",
+        "build_type": build_type,
+        "duration_seconds": elapsed,
+        "success": result.returncode == 0,
+        "exit_code": result.returncode,
+        "command": shell_join(build_command),
+        "raw_log_path": str(log_path),
+        "timing_summary_categories": parse_timing_summary(result.stdout + result.stderr),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    artifact_stem = f"{timestamp}-{args.scheme.replace(' ', '-').lower()}"
+    base_command = command_base(args)
+
+    if not args.skip_warmup:
+        warmup = run_command([*base_command, "build"])
+        if warmup.returncode != 0:
+          sys.stderr.write(warmup.stdout + warmup.stderr)
+          return warmup.returncode
+        warmup_clean = run_command([*base_command, "clean"])
+        if warmup_clean.returncode != 0:
+            sys.stderr.write(warmup_clean.stdout + warmup_clean.stderr)
+            return warmup_clean.returncode
+        warmup_rebuild = run_command([*base_command, "build"])
+        if warmup_rebuild.returncode != 0:
+            sys.stderr.write(warmup_rebuild.stdout + warmup_rebuild.stderr)
+            return warmup_rebuild.returncode
+
+    runs: Dict[str, list] = {"clean": [], "incremental": []}
+
+    for index in range(1, args.repeats + 1):
+        clean_result = run_command([*base_command, "clean"])
+        clean_log_path = output_dir / f"{artifact_stem}-clean-prep-{index}.log"
+        clean_log_path.write_text(clean_result.stdout + clean_result.stderr)
+        if clean_result.returncode != 0:
+            sys.stderr.write(clean_result.stdout + clean_result.stderr)
+            return clean_result.returncode
+        runs["clean"].append(measure_build(base_command, artifact_stem, output_dir, "clean", index))
+
+    # --- Cached clean builds ---------------------------------------------------
+    # When COMPILATION_CACHE_ENABLE_CACHING is enabled, the compilation cache lives outside
+    # DerivedData and survives product deletion.  We measure "cached clean"
+    # builds by pointing DerivedData at a temp directory, warming the cache with
+    # one build, then deleting the DerivedData directory (but not the cache)
+    # before each measured rebuild.  This captures the realistic scenario:
+    # branch switching, pulling changes, or Clean Build Folder.
+    should_cached_clean = not args.no_cached_clean and detect_compilation_caching(base_command)
+    if should_cached_clean:
+        dd_path = Path(args.derived_data_path) if args.derived_data_path else Path(
+            tempfile.mkdtemp(prefix="xcode-bench-dd-")
+        )
+        cached_cmd = list(base_command)
+        if not args.derived_data_path:
+            cached_cmd.extend(["-derivedDataPath", str(dd_path)])
+
+        cache_warmup = run_command([*cached_cmd, "build"])
+        if cache_warmup.returncode != 0:
+            sys.stderr.write("Warning: cached clean warmup build failed, skipping cached clean benchmarks.\n")
+            sys.stderr.write(cache_warmup.stdout + cache_warmup.stderr)
+            should_cached_clean = False
+
+    if should_cached_clean:
+        runs["cached_clean"] = []
+        for index in range(1, args.repeats + 1):
+            shutil.rmtree(dd_path, ignore_errors=True)
+            runs["cached_clean"].append(
+                measure_build(cached_cmd, artifact_stem, output_dir, "cached-clean", index)
+            )
+        shutil.rmtree(dd_path, ignore_errors=True)
+
+    # --- Incremental / zero-change builds --------------------------------------
+    incremental_label = "incremental"
+    if args.touch_file:
+        touch_path = Path(args.touch_file)
+        if not touch_path.exists():
+            sys.stderr.write(f"--touch-file path does not exist: {touch_path}\n")
+            return 1
+        incremental_label = "incremental"
+    else:
+        incremental_label = "zero-change"
+
+    for index in range(1, args.repeats + 1):
+        if args.touch_file:
+            touch_path.touch()
+        runs["incremental"].append(
+            measure_build(base_command, artifact_stem, output_dir, incremental_label, index)
+        )
+
+    summary: Dict[str, object] = {
+        "clean": stats_for(runs["clean"]),
+        "incremental": stats_for(runs["incremental"]),
+    }
+    if "cached_clean" in runs:
+        summary["cached_clean"] = stats_for(runs["cached_clean"])
+
+    artifact = {
+        "schema_version": "1.2.0" if "cached_clean" in runs else "1.1.0",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "build": {
+            "entrypoint": "workspace" if args.workspace else "project",
+            "path": args.workspace or args.project,
+            "scheme": args.scheme,
+            "configuration": args.configuration,
+            "destination": args.destination or "",
+            "derived_data_path": args.derived_data_path or "",
+            "command": shell_join(base_command),
+        },
+        "environment": {
+            "host": platform.node(),
+            "macos_version": platform.platform(),
+            "xcode_version": xcode_version(),
+            "cwd": os.getcwd(),
+        },
+        "runs": runs,
+        "summary": summary,
+        "notes": [f"touch-file: {args.touch_file}"] if args.touch_file else [],
+    }
+
+    artifact_path = output_dir / f"{artifact_stem}.json"
+    artifact_path.write_text(json.dumps(artifact, indent=2) + "\n")
+
+    print(f"Saved benchmark artifact: {artifact_path}")
+    print(f"Clean median: {artifact['summary']['clean']['median_seconds']}s")
+    if "cached_clean" in artifact["summary"]:
+        print(f"Cached clean median: {artifact['summary']['cached_clean']['median_seconds']}s")
+    inc_label = "Incremental" if args.touch_file else "Zero-change"
+    print(f"{inc_label} median: {artifact['summary']['incremental']['median_seconds']}s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/xcode-build-orchestrator/scripts/diagnose_compilation.py
+++ b/.agents/skills/xcode-build-orchestrator/scripts/diagnose_compilation.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+
+"""Run a single Xcode build with -Xfrontend diagnostics to find slow type-checking."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+_TYPECHECK_RE = re.compile(
+    r"^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+): warning: "
+    r"(?P<kind>instance method|global function|getter|type-check|expression) "
+    r"'?(?P<name>[^']*?)'?\s+took\s+(?P<ms>\d+)ms\s+to\s+type-check"
+)
+
+_EXPRESSION_RE = re.compile(
+    r"^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+): warning: "
+    r"expression took\s+(?P<ms>\d+)ms\s+to\s+type-check"
+)
+
+_FILE_TIME_RE = re.compile(
+    r"^\s*(?P<seconds>\d+(?:\.\d+)?)\s+seconds\s+.*\s+compiling\s+(?P<file>\S+)"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run an Xcode build with -Xfrontend type-checking diagnostics."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to the .xcworkspace file")
+    group.add_argument("--project", help="Path to the .xcodeproj file")
+    parser.add_argument("--scheme", required=True, help="Scheme to build")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--destination", help="xcodebuild destination string")
+    parser.add_argument("--derived-data-path", help="DerivedData path override")
+    parser.add_argument("--output-dir", default=".build-benchmark", help="Output directory")
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=100,
+        help="Millisecond threshold for -warn-long-function-bodies and "
+        "-warn-long-expression-type-checking (default: 100)",
+    )
+    parser.add_argument("--skip-clean", action="store_true", help="Skip clean before build")
+    parser.add_argument(
+        "--per-file-timing",
+        action="store_true",
+        help="Add -Xfrontend -debug-time-compilation to report per-file compile times.",
+    )
+    parser.add_argument(
+        "--stats-output",
+        action="store_true",
+        help="Add -Xfrontend -stats-output-dir to collect detailed compiler statistics.",
+    )
+    parser.add_argument(
+        "--extra-arg",
+        action="append",
+        default=[],
+        help="Additional xcodebuild argument. Can be passed multiple times.",
+    )
+    return parser.parse_args()
+
+
+def command_base(args: argparse.Namespace) -> List[str]:
+    command = ["xcodebuild"]
+    if args.workspace:
+        command.extend(["-workspace", args.workspace])
+    if args.project:
+        command.extend(["-project", args.project])
+    command.extend(["-scheme", args.scheme, "-configuration", args.configuration])
+    if args.destination:
+        command.extend(["-destination", args.destination])
+    if args.derived_data_path:
+        command.extend(["-derivedDataPath", args.derived_data_path])
+    command.extend(args.extra_arg)
+    return command
+
+
+def parse_diagnostics(output: str) -> List[Dict]:
+    """Extract type-checking warnings from xcodebuild output."""
+    warnings: List[Dict] = []
+    seen = set()
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        match = _TYPECHECK_RE.match(line)
+        if match:
+            key = (match.group("file"), match.group("line"), match.group("col"), "function-body")
+            if key in seen:
+                continue
+            seen.add(key)
+            warnings.append(
+                {
+                    "file": match.group("file"),
+                    "line": int(match.group("line")),
+                    "column": int(match.group("col")),
+                    "duration_ms": int(match.group("ms")),
+                    "kind": "function-body",
+                    "name": match.group("name"),
+                }
+            )
+            continue
+        match = _EXPRESSION_RE.match(line)
+        if match:
+            key = (match.group("file"), match.group("line"), match.group("col"), "expression")
+            if key in seen:
+                continue
+            seen.add(key)
+            warnings.append(
+                {
+                    "file": match.group("file"),
+                    "line": int(match.group("line")),
+                    "column": int(match.group("col")),
+                    "duration_ms": int(match.group("ms")),
+                    "kind": "expression",
+                    "name": "",
+                }
+            )
+    warnings.sort(key=lambda w: w["duration_ms"], reverse=True)
+    return warnings
+
+
+def parse_file_timings(output: str) -> List[Dict]:
+    """Extract per-file compile times from -debug-time-compilation output."""
+    timings: List[Dict] = []
+    seen = set()
+    for raw_line in output.splitlines():
+        match = _FILE_TIME_RE.match(raw_line.strip())
+        if match:
+            filepath = match.group("file")
+            if filepath in seen:
+                continue
+            seen.add(filepath)
+            timings.append(
+                {
+                    "file": filepath,
+                    "duration_seconds": float(match.group("seconds")),
+                }
+            )
+    timings.sort(key=lambda t: t["duration_seconds"], reverse=True)
+    return timings
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    scheme_slug = args.scheme.replace(" ", "-").lower()
+    artifact_stem = f"{timestamp}-{scheme_slug}"
+    base = command_base(args)
+
+    if not args.skip_clean:
+        print("Cleaning build products...")
+        clean = subprocess.run([*base, "clean"], capture_output=True, text=True)
+        if clean.returncode != 0:
+            sys.stderr.write(clean.stdout + clean.stderr)
+            return clean.returncode
+
+    threshold = str(args.threshold)
+    swift_flags = (
+        f"$(inherited) -Xfrontend -warn-long-function-bodies={threshold} "
+        f"-Xfrontend -warn-long-expression-type-checking={threshold}"
+    )
+    if args.per_file_timing:
+        swift_flags += " -Xfrontend -debug-time-compilation"
+
+    stats_dir: Optional[Path] = None
+    if args.stats_output:
+        stats_dir = output_dir / f"{artifact_stem}-stats"
+        stats_dir.mkdir(parents=True, exist_ok=True)
+        swift_flags += f" -Xfrontend -stats-output-dir -Xfrontend {stats_dir}"
+
+    build_command = [
+        *base,
+        "build",
+        "-showBuildTimingSummary",
+        f"OTHER_SWIFT_FLAGS={swift_flags}",
+    ]
+
+    extras = []
+    if args.per_file_timing:
+        extras.append("per-file timing")
+    if args.stats_output:
+        extras.append("stats output")
+    extras_label = f" + {', '.join(extras)}" if extras else ""
+    print(f"Building with type-check threshold {threshold}ms{extras_label}...")
+    started = time.perf_counter()
+    result = subprocess.run(build_command, capture_output=True, text=True)
+    elapsed = round(time.perf_counter() - started, 3)
+
+    combined_output = result.stdout + result.stderr
+    log_path = output_dir / f"{artifact_stem}-diagnostics.log"
+    log_path.write_text(combined_output)
+
+    warnings = parse_diagnostics(combined_output)
+
+    file_timings: Optional[List[Dict]] = None
+    if args.per_file_timing:
+        file_timings = parse_file_timings(combined_output)
+
+    artifact = {
+        "schema_version": "1.0.0",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "type": "compilation-diagnostics",
+        "build": {
+            "entrypoint": "workspace" if args.workspace else "project",
+            "path": args.workspace or args.project,
+            "scheme": args.scheme,
+            "configuration": args.configuration,
+            "destination": args.destination or "",
+        },
+        "threshold_ms": args.threshold,
+        "build_duration_seconds": elapsed,
+        "build_success": result.returncode == 0,
+        "raw_log_path": str(log_path),
+        "warnings": warnings,
+        "summary": {
+            "total_warnings": len(warnings),
+            "function_body_warnings": sum(1 for w in warnings if w["kind"] == "function-body"),
+            "expression_warnings": sum(1 for w in warnings if w["kind"] == "expression"),
+            "slowest_ms": warnings[0]["duration_ms"] if warnings else 0,
+        },
+    }
+
+    if file_timings is not None:
+        artifact["per_file_timings"] = file_timings
+    if stats_dir is not None:
+        artifact["stats_dir"] = str(stats_dir)
+
+    artifact_path = output_dir / f"{artifact_stem}-diagnostics.json"
+    artifact_path.write_text(json.dumps(artifact, indent=2) + "\n")
+
+    print(f"\nSaved diagnostics artifact: {artifact_path}")
+    print(f"Build {'succeeded' if result.returncode == 0 else 'failed'} in {elapsed}s")
+    print(f"Found {len(warnings)} type-check warnings above {threshold}ms threshold\n")
+
+    if warnings:
+        print(f"{'Duration':>10}  {'Kind':<15}  {'Location'}")
+        print(f"{'--------':>10}  {'----':<15}  {'--------'}")
+        for w in warnings[:20]:
+            loc = f"{w['file']}:{w['line']}:{w['column']}"
+            label = w["name"] if w["name"] else "(expression)"
+            print(f"{w['duration_ms']:>8}ms  {w['kind']:<15}  {loc}  {label}")
+        if len(warnings) > 20:
+            print(f"\n  ... and {len(warnings) - 20} more (see {artifact_path})")
+    else:
+        print("No type-checking hotspots found above threshold.")
+
+    if file_timings:
+        print(f"\nPer-file compile times (top 20):\n")
+        print(f"{'Duration':>12}  {'File'}")
+        print(f"{'--------':>12}  {'----'}")
+        for t in file_timings[:20]:
+            print(f"{t['duration_seconds']:>10.3f}s  {t['file']}")
+        if len(file_timings) > 20:
+            print(f"\n  ... and {len(file_timings) - 20} more (see {artifact_path})")
+
+    if stats_dir is not None:
+        stat_files = list(stats_dir.glob("*.json"))
+        print(f"\nCompiler statistics: {len(stat_files)} files written to {stats_dir}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/xcode-build-orchestrator/scripts/generate_optimization_report.py
+++ b/.agents/skills/xcode-build-orchestrator/scripts/generate_optimization_report.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+
+"""Generate a Markdown optimization report from benchmark and diagnostics artifacts."""
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# pbxproj helpers
+# ---------------------------------------------------------------------------
+
+_SETTING_RE = re.compile(r"^\s*([A-Z_][A-Z_0-9]*)\s*=\s*(.+?)\s*;", re.MULTILINE)
+
+_CONFIG_ID_RE = re.compile(r"([0-9A-F]{24})\s*/\*\s*(Debug|Release)\s*\*/")
+
+_CONFIG_LIST_RE = re.compile(
+    r"([0-9A-F]{24})\s*/\*\s*Build configuration list for "
+    r"(?P<kind>PBXProject|PBXNativeTarget)\s+\"(?P<name>[^\"]+)\"\s*\*/"
+)
+
+
+def _parse_all_build_configs(pbxproj: str) -> Dict[str, Tuple[str, Dict[str, str]]]:
+    """Return {config_id: (config_name, {key: value})} for every XCBuildConfiguration."""
+    configs: Dict[str, Tuple[str, Dict[str, str]]] = {}
+    for match in re.finditer(
+        r"([0-9A-F]{24})\s*/\*\s*(Debug|Release)\s*\*/\s*=\s*\{\s*"
+        r"isa\s*=\s*XCBuildConfiguration;\s*buildSettings\s*=\s*\{([^}]*)\}",
+        pbxproj,
+        re.DOTALL,
+    ):
+        config_id = match.group(1)
+        config_name = match.group(2)
+        body = match.group(3)
+        settings: Dict[str, str] = {}
+        for s in _SETTING_RE.finditer(body):
+            val = s.group(2).strip().strip('"')
+            settings[s.group(1)] = val
+        configs[config_id] = (config_name, settings)
+    return configs
+
+
+def _resolve_config_list(
+    pbxproj: str, all_configs: Dict[str, Tuple[str, Dict[str, str]]], kind: str
+) -> Dict[str, Dict[str, Dict[str, str]]]:
+    """Resolve configuration lists for a given kind (PBXProject or PBXNativeTarget)."""
+    results: Dict[str, Dict[str, Dict[str, str]]] = {}
+    for list_match in _CONFIG_LIST_RE.finditer(pbxproj):
+        if list_match.group("kind") != kind:
+            continue
+        entity_name = list_match.group("name")
+        list_id = list_match.group(1)
+        block_start = pbxproj.find(f"{list_id} /*", list_match.end())
+        if block_start == -1:
+            block_start = list_match.start()
+        block = pbxproj[block_start : block_start + 500]
+        configs: Dict[str, Dict[str, str]] = {}
+        for cid_match in _CONFIG_ID_RE.finditer(block):
+            cid = cid_match.group(1)
+            if cid in all_configs:
+                cname, settings = all_configs[cid]
+                configs[cname] = settings
+        if configs:
+            results[entity_name] = configs
+    return results
+
+
+def _parse_project_level_configs(pbxproj: str) -> Dict[str, Dict[str, str]]:
+    """Extract project-level Debug and Release build settings."""
+    all_configs = _parse_all_build_configs(pbxproj)
+    resolved = _resolve_config_list(pbxproj, all_configs, "PBXProject")
+    if resolved:
+        return next(iter(resolved.values()))
+    return {}
+
+
+def _parse_target_configs(pbxproj: str) -> Dict[str, Dict[str, Dict[str, str]]]:
+    """Extract per-target Debug and Release build settings."""
+    all_configs = _parse_all_build_configs(pbxproj)
+    return _resolve_config_list(pbxproj, all_configs, "PBXNativeTarget")
+
+
+# ---------------------------------------------------------------------------
+# Best-practices audit
+# ---------------------------------------------------------------------------
+
+_DEBUG_EXPECTATIONS: List[Tuple[str, str, str]] = [
+    ("SWIFT_COMPILATION_MODE", "singlefile", "Single-file mode recompiles only changed files (Xcode UI: Incremental)"),
+    ("SWIFT_OPTIMIZATION_LEVEL", "-Onone", "Optimization passes add compile time without debug benefit"),
+    ("GCC_OPTIMIZATION_LEVEL", "0", "C/ObjC optimization adds compile time without debug benefit"),
+    ("ONLY_ACTIVE_ARCH", "YES", "Building all architectures multiplies compile and link time"),
+    ("DEBUG_INFORMATION_FORMAT", "dwarf", "dwarf-with-dsym generates a separate dSYM, adding overhead"),
+    ("ENABLE_TESTABILITY", "YES", "Required for @testable import during development"),
+    ("EAGER_LINKING", "YES", "Allows linker to start before all compilation finishes, reducing wall-clock time"),
+]
+
+_GENERAL_EXPECTATIONS: List[Tuple[str, str, str]] = [
+    ("COMPILATION_CACHE_ENABLE_CACHING", "YES", "Caches compilation results so repeat builds of unchanged inputs are served from cache. Measured 5-14% faster clean builds across tested projects; benefit compounds during branch switching and pulling changes"),
+]
+
+_RELEASE_EXPECTATIONS: List[Tuple[str, str, str]] = [
+    ("SWIFT_COMPILATION_MODE", "wholemodule", "Whole-module optimization produces faster runtime code"),
+    ("SWIFT_OPTIMIZATION_LEVEL", "-O", "Optimized binaries for production (-Osize also acceptable)"),
+    ("GCC_OPTIMIZATION_LEVEL", "s", "Optimizes C/ObjC for size in release"),
+    ("ONLY_ACTIVE_ARCH", "NO", "Release builds must include all architectures for distribution"),
+    ("DEBUG_INFORMATION_FORMAT", "dwarf-with-dsym", "dSYM bundles are needed for crash symbolication"),
+    ("ENABLE_TESTABILITY", "NO", "Removes internal-symbol export overhead from release builds"),
+]
+
+_CONSISTENCY_KEYS = [
+    "SWIFT_COMPILATION_MODE",
+    "SWIFT_OPTIMIZATION_LEVEL",
+    "ONLY_ACTIVE_ARCH",
+    "DEBUG_INFORMATION_FORMAT",
+]
+
+
+def _effective_value(
+    project: Dict[str, str], target: Dict[str, str], key: str
+) -> Optional[str]:
+    return target.get(key, project.get(key))
+
+
+def _check(actual: Optional[str], expected: str) -> bool:
+    if actual is None:
+        if expected in ("singlefile",):
+            return True
+        return False
+    if expected == "-O" and actual in ("-O", '"-O"', '"-Osize"', "-Osize"):
+        return True
+    return actual.strip('"') == expected
+
+
+def _merged_project_settings(
+    project_configs: Dict[str, Dict[str, str]],
+) -> Dict[str, str]:
+    """Return a flat dict of all settings across Debug and Release for general checks."""
+    merged: Dict[str, str] = {}
+    for config in project_configs.values():
+        merged.update(config)
+    return merged
+
+
+def _audit_config(
+    project_settings: Dict[str, str],
+    expectations: List[Tuple[str, str, str]],
+    config_name: str,
+) -> List[str]:
+    lines: List[str] = []
+    for key, expected, _reason in expectations:
+        actual = project_settings.get(key)
+        display_actual = actual if actual else "(unset)"
+        passed = _check(actual, expected)
+        mark = "[x]" if passed else "[ ]"
+        lines.append(f"- {mark} `{key}`: `{display_actual}` (recommended: `{expected}`)")
+    return lines
+
+
+def _audit_consistency(
+    project_configs: Dict[str, Dict[str, str]],
+    target_configs: Dict[str, Dict[str, Dict[str, str]]],
+) -> List[str]:
+    lines: List[str] = []
+    for key in _CONSISTENCY_KEYS:
+        overrides = []
+        for target_name, configs in target_configs.items():
+            for config_name in ("Debug", "Release"):
+                target_settings = configs.get(config_name, {})
+                if key in target_settings:
+                    proj_val = project_configs.get(config_name, {}).get(key, "(unset)")
+                    tgt_val = target_settings[key]
+                    if tgt_val != proj_val:
+                        overrides.append(
+                            f"{target_name} ({config_name}): `{tgt_val}` vs project `{proj_val}`"
+                        )
+        if overrides:
+            lines.append(f"- [ ] `{key}` has target-level overrides:")
+            for o in overrides:
+                lines.append(f"  - {o}")
+        else:
+            lines.append(f"- [x] `{key}` is consistent across all targets")
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Auto-generated recommendations from audit
+# ---------------------------------------------------------------------------
+
+
+def _auto_recommendations_from_audit(
+    project_configs: Dict[str, Dict[str, str]],
+) -> Dict[str, Any]:
+    """Generate basic recommendations from failing build settings audit checks."""
+    items: List[Dict[str, str]] = []
+
+    debug_settings = project_configs.get("Debug", {})
+    for key, expected, reason in _DEBUG_EXPECTATIONS:
+        if not _check(debug_settings.get(key), expected):
+            actual = debug_settings.get(key, "(unset)")
+            items.append({
+                "title": f"Set `{key}` to `{expected}` for Debug",
+                "category": "build-settings",
+                "observed_evidence": f"Current value: `{actual}`. {reason}.",
+                "estimated_impact": "Medium",
+                "confidence": "High",
+                "risk_level": "Low",
+            })
+
+    merged = {}
+    for config in project_configs.values():
+        merged.update(config)
+    for key, expected, reason in _GENERAL_EXPECTATIONS:
+        if not _check(merged.get(key), expected):
+            actual = merged.get(key, "(unset)")
+            items.append({
+                "title": f"Enable `{key} = {expected}`",
+                "category": "build-settings",
+                "observed_evidence": f"Current value: `{actual}`. {reason}.",
+                "estimated_impact": "High",
+                "confidence": "High",
+                "risk_level": "Low",
+            })
+
+    release_settings = project_configs.get("Release", {})
+    for key, expected, reason in _RELEASE_EXPECTATIONS:
+        if not _check(release_settings.get(key), expected):
+            actual = release_settings.get(key, "(unset)")
+            items.append({
+                "title": f"Set `{key}` to `{expected}` for Release",
+                "category": "build-settings",
+                "observed_evidence": f"Current value: `{actual}`. {reason}.",
+                "estimated_impact": "Medium",
+                "confidence": "High",
+                "risk_level": "Low",
+            })
+
+    if not items:
+        return {"recommendations": []}
+    return {"recommendations": items}
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+
+def _section_context(benchmark: Dict[str, Any]) -> str:
+    build = benchmark.get("build", {})
+    env = benchmark.get("environment", {})
+    lines = [
+        "## Project Context\n",
+        f"- **Project:** `{build.get('path', 'unknown')}`",
+        f"- **Scheme:** `{build.get('scheme', 'unknown')}`",
+        f"- **Configuration:** `{build.get('configuration', 'unknown')}`",
+        f"- **Destination:** `{build.get('destination', 'unknown')}`",
+        f"- **Xcode:** {env.get('xcode_version', 'unknown').replace(chr(10), ' ')}",
+        f"- **macOS:** {env.get('macos_version', 'unknown')}",
+        f"- **Date:** {benchmark.get('created_at', 'unknown')}",
+        f"- **Benchmark artifact:** `{benchmark.get('_artifact_path', 'unknown')}`",
+    ]
+    return "\n".join(lines)
+
+
+def _section_baseline(benchmark: Dict[str, Any]) -> str:
+    summary = benchmark.get("summary", {})
+    clean = summary.get("clean", {})
+    cached_clean = summary.get("cached_clean", {})
+    incremental = summary.get("incremental", {})
+    has_cached = bool(cached_clean and cached_clean.get("count", 0) > 0)
+
+    if has_cached:
+        lines = [
+            "## Baseline Benchmarks\n",
+            "| Metric | Clean | Cached Clean | Incremental |",
+            "|--------|-------|-------------|-------------|",
+            f"| Median | {clean.get('median_seconds', 0):.3f}s | {cached_clean.get('median_seconds', 0):.3f}s | {incremental.get('median_seconds', 0):.3f}s |",
+            f"| Min | {clean.get('min_seconds', 0):.3f}s | {cached_clean.get('min_seconds', 0):.3f}s | {incremental.get('min_seconds', 0):.3f}s |",
+            f"| Max | {clean.get('max_seconds', 0):.3f}s | {cached_clean.get('max_seconds', 0):.3f}s | {incremental.get('max_seconds', 0):.3f}s |",
+            f"| Runs | {clean.get('count', 0)} | {cached_clean.get('count', 0)} | {incremental.get('count', 0)} |",
+        ]
+        lines.append(
+            "\n> **Cached Clean** = clean build with a warm compilation cache. "
+            "This is the realistic scenario for branch switching, pulling changes, or "
+            "Clean Build Folder. The compilation cache lives outside DerivedData and "
+            "survives product deletion.\n"
+        )
+    else:
+        lines = [
+            "## Baseline Benchmarks\n",
+            "| Metric | Clean | Incremental |",
+            "|--------|-------|-------------|",
+            f"| Median | {clean.get('median_seconds', 0):.3f}s | {incremental.get('median_seconds', 0):.3f}s |",
+            f"| Min | {clean.get('min_seconds', 0):.3f}s | {incremental.get('min_seconds', 0):.3f}s |",
+            f"| Max | {clean.get('max_seconds', 0):.3f}s | {incremental.get('max_seconds', 0):.3f}s |",
+            f"| Runs | {clean.get('count', 0)} | {incremental.get('count', 0)} |",
+        ]
+
+    build_types = ["clean", "cached_clean", "incremental"] if has_cached else ["clean", "incremental"]
+    label_map = {"clean": "Clean", "cached_clean": "Cached Clean", "incremental": "Incremental"}
+    for build_type in build_types:
+        runs = benchmark.get("runs", {}).get(build_type, [])
+        all_cats: Dict[str, Dict] = {}
+        for run in runs:
+            for cat in run.get("timing_summary_categories", []):
+                name = cat["name"]
+                if name not in all_cats:
+                    all_cats[name] = {"seconds": 0.0, "task_count": 0}
+                all_cats[name]["seconds"] += cat["seconds"]
+                all_cats[name]["task_count"] += cat.get("task_count", 0)
+        if all_cats:
+            count = len(runs) or 1
+            ranked = sorted(all_cats.items(), key=lambda x: x[1]["seconds"], reverse=True)
+            label = label_map.get(build_type, build_type.title())
+            lines.append(f"\n### {label} Build Timing Summary\n")
+            lines.append(
+                "> **Note:** These are aggregated task times across all CPU cores. "
+                "Because Xcode runs many tasks in parallel, these totals typically exceed "
+                "the actual build wait time shown above. A large number here does not mean "
+                "it is blocking your build.\n"
+            )
+            lines.append("| Category | Tasks | Seconds |")
+            lines.append("|----------|------:|--------:|")
+            for name, data in ranked:
+                avg_sec = data["seconds"] / count
+                tasks = data["task_count"] // count if data["task_count"] else ""
+                lines.append(f"| {name} | {tasks} | {avg_sec:.3f}s |")
+
+    return "\n".join(lines)
+
+
+def _section_settings_audit(
+    project_configs: Dict[str, Dict[str, str]],
+    target_configs: Dict[str, Dict[str, Dict[str, str]]],
+) -> str:
+    lines = ["## Build Settings Audit\n"]
+
+    lines.append("### Debug Configuration\n")
+    lines.extend(_audit_config(project_configs.get("Debug", {}), _DEBUG_EXPECTATIONS, "Debug"))
+
+    lines.append("\n### General (All Configurations)\n")
+    merged = _merged_project_settings(project_configs)
+    lines.extend(_audit_config(merged, _GENERAL_EXPECTATIONS, "General"))
+
+    lines.append("\n### Release Configuration\n")
+    lines.extend(_audit_config(project_configs.get("Release", {}), _RELEASE_EXPECTATIONS, "Release"))
+
+    lines.append("\n### Cross-Target Consistency\n")
+    lines.extend(_audit_consistency(project_configs, target_configs))
+
+    return "\n".join(lines)
+
+
+def _section_diagnostics(diagnostics: Optional[Dict[str, Any]]) -> str:
+    if diagnostics is None:
+        return "## Compilation Diagnostics\n\nNo diagnostics artifact provided. Run `diagnose_compilation.py` to identify type-checking hotspots."
+    warnings = diagnostics.get("warnings", [])
+    summary = diagnostics.get("summary", {})
+    threshold = diagnostics.get("threshold_ms", 100)
+    lines = [
+        "## Compilation Diagnostics\n",
+        f"Threshold: {threshold}ms | "
+        f"Total warnings: {summary.get('total_warnings', 0)} | "
+        f"Function bodies: {summary.get('function_body_warnings', 0)} | "
+        f"Expressions: {summary.get('expression_warnings', 0)}\n",
+    ]
+    if warnings:
+        lines.append("| Duration | Kind | File | Line | Name |")
+        lines.append("|---------:|------|------|-----:|------|")
+        for w in warnings[:30]:
+            short_file = Path(w["file"]).name
+            name = w.get("name", "") or "(expression)"
+            lines.append(
+                f"| {w['duration_ms']}ms | {w['kind']} | {short_file} | {w['line']} | {name} |"
+            )
+        if len(warnings) > 30:
+            lines.append(f"\n*... and {len(warnings) - 30} more warnings (see full artifact)*")
+    else:
+        lines.append("No type-checking hotspots found above threshold.")
+    return "\n".join(lines)
+
+
+def _section_recommendations(recommendations: Optional[Dict[str, Any]]) -> str:
+    if recommendations is None:
+        return "## Prioritized Recommendations\n\nNo recommendations artifact provided."
+    items = recommendations.get("recommendations", [])
+    if not items:
+        return "## Prioritized Recommendations\n\nNo recommendations found."
+    lines = ["## Prioritized Recommendations\n"]
+    for i, item in enumerate(items, 1):
+        title = item.get("title", "Untitled")
+        lines.append(f"### {i}. {title}\n")
+        for field, label in [
+            ("wait_time_impact", "Wait-Time Impact"),
+            ("actionability", "Actionability"),
+            ("category", "Category"),
+            ("observed_evidence", "Evidence"),
+            ("estimated_impact", "Impact"),
+            ("confidence", "Confidence"),
+            ("risk_level", "Risk"),
+            ("scope", "Scope"),
+        ]:
+            val = item.get(field)
+            if val is None:
+                continue
+            if isinstance(val, list):
+                lines.append(f"**{label}:**")
+                for entry in val:
+                    lines.append(f"- {entry}")
+            else:
+                lines.append(f"**{label}:** {val}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _section_approval(recommendations: Optional[Dict[str, Any]]) -> str:
+    if recommendations is None:
+        return "## Approval Checklist\n\nNo recommendations to approve."
+    items = recommendations.get("recommendations", [])
+    if not items:
+        return "## Approval Checklist\n\nNo recommendations to approve."
+    lines = ["## Approval Checklist\n"]
+    for i, item in enumerate(items, 1):
+        title = item.get("title", "Untitled")
+        wait_impact = item.get("wait_time_impact", "")
+        impact = item.get("estimated_impact", "")
+        risk = item.get("risk_level", "")
+        actionability = item.get("actionability", "")
+        impact_str = wait_impact if wait_impact else impact
+        actionability_str = f" | Actionability: {actionability}" if actionability else ""
+        lines.append(f"- [ ] **{i}. {title}** -- Impact: {impact_str}{actionability_str} | Risk: {risk}")
+    return "\n".join(lines)
+
+
+def _section_next_steps(benchmark: Dict[str, Any]) -> str:
+    build = benchmark.get("build", {})
+    command = build.get("command", "xcodebuild build")
+    lines = [
+        "## Next Steps\n",
+        "After implementing approved changes, re-benchmark with the same inputs:\n",
+        "```bash",
+        f"python3 scripts/benchmark_builds.py \\",
+    ]
+    if build.get("entrypoint") == "workspace":
+        lines.append(f"  --workspace {build.get('path', 'App.xcworkspace')} \\")
+    else:
+        lines.append(f"  --project {build.get('path', 'App.xcodeproj')} \\")
+    lines.extend([
+        f"  --scheme {build.get('scheme', 'App')} \\",
+        f"  --configuration {build.get('configuration', 'Debug')} \\",
+    ])
+    if build.get("destination"):
+        lines.append(f'  --destination "{build["destination"]}" \\')
+    lines.append("  --output-dir .build-benchmark")
+    lines.append("```\n")
+    lines.append("Compare the new wall-clock medians against the baseline. Report results as:")
+    lines.append('"Your [clean/incremental] build now takes X.Xs (was Y.Ys) -- Z.Zs faster/slower."')
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a Markdown build optimization report.")
+    parser.add_argument("--benchmark", required=True, help="Path to benchmark JSON artifact")
+    parser.add_argument("--recommendations", help="Path to recommendations JSON")
+    parser.add_argument("--diagnostics", help="Path to diagnostics JSON")
+    parser.add_argument("--project-path", help="Path to .xcodeproj for build settings audit")
+    parser.add_argument("--output", help="Output Markdown path (default: stdout)")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    benchmark = json.loads(Path(args.benchmark).read_text())
+    benchmark["_artifact_path"] = args.benchmark
+
+    recommendations = None
+    if args.recommendations:
+        recommendations = json.loads(Path(args.recommendations).read_text())
+
+    diagnostics = None
+    if args.diagnostics:
+        diagnostics = json.loads(Path(args.diagnostics).read_text())
+
+    project_configs: Dict[str, Dict[str, str]] = {}
+    target_configs: Dict[str, Dict[str, Dict[str, str]]] = {}
+    if args.project_path:
+        pbxproj_path = Path(args.project_path) / "project.pbxproj"
+        if pbxproj_path.exists():
+            pbxproj = pbxproj_path.read_text()
+            project_configs = _parse_project_level_configs(pbxproj)
+            target_configs = _parse_target_configs(pbxproj)
+
+    if recommendations is None and project_configs:
+        auto = _auto_recommendations_from_audit(project_configs)
+        if auto["recommendations"]:
+            recommendations = auto
+
+    sections = [
+        "# Xcode Build Optimization Plan\n",
+        _section_context(benchmark),
+        _section_baseline(benchmark),
+    ]
+
+    if project_configs:
+        sections.append(_section_settings_audit(project_configs, target_configs))
+
+    sections.append(_section_diagnostics(diagnostics))
+    sections.append(_section_recommendations(recommendations))
+    sections.append(_section_approval(recommendations))
+    sections.append(_section_next_steps(benchmark))
+
+    report = "\n\n".join(sections) + "\n"
+
+    if args.output:
+        Path(args.output).write_text(report)
+        print(f"Saved optimization report: {args.output}")
+    else:
+        print(report, end="")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/xcode-compilation-analyzer/SKILL.md
+++ b/.agents/skills/xcode-compilation-analyzer/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: xcode-compilation-analyzer
+description: Analyze Swift and mixed-language compile hotspots using build timing summaries and Swift frontend diagnostics, then produce a recommend-first source-level optimization plan. Use when a developer reports slow compilation, type-checking warnings, expensive clean-build compile phases, long CompileSwiftSources tasks, warn-long-function-bodies output, or wants to speed up Swift type checking.
+---
+
+# Xcode Compilation Analyzer
+
+Use this skill when compile time, not just general project configuration, looks like the bottleneck.
+
+## Core Rules
+
+- Start from evidence, ideally a recent `.build-benchmark/` artifact or raw timing-summary output.
+- Prefer analysis-only compiler flags over persistent project edits during investigation.
+- Rank findings by expected **wall-clock** impact, not cumulative compile-time impact. When compile tasks are heavily parallelized (sum of compile categories >> wall-clock median), note that fixing individual hotspots may improve parallel efficiency without reducing build wait time.
+- When the evidence points to parallelized work rather than serial bottlenecks, label recommendations as "Reduces compiler workload (parallel)" rather than "Reduces build time."
+- Do not edit source or build settings without explicit developer approval.
+
+## What To Inspect
+
+- `Build Timing Summary` output from clean and incremental builds
+- long-running `CompileSwiftSources` or per-file compilation tasks
+- `SwiftEmitModule` time -- can reach 60s+ after a single-line change in large modules; if it dominates incremental builds, the module is likely too large or macro-heavy
+- `Planning Swift module` time -- if this category is disproportionately large in incremental builds (up to 30s per module), it signals unexpected input invalidation or macro-related rebuild cascading
+- ad hoc runs with:
+  - `-Xfrontend -warn-long-expression-type-checking=<ms>`
+  - `-Xfrontend -warn-long-function-bodies=<ms>`
+- deeper diagnostic flags for thorough investigation:
+  - `-Xfrontend -debug-time-compilation` -- per-file compile times to rank the slowest files
+  - `-Xfrontend -debug-time-function-bodies` -- per-function compile times (unfiltered, complements the threshold-based warning flags)
+  - `-Xswiftc -driver-time-compilation` -- driver-level timing to isolate driver overhead
+  - `-Xfrontend -stats-output-dir <path>` -- detailed compiler statistics (JSON) per compilation unit for root-cause analysis
+- mixed Swift and Objective-C surfaces that increase bridging work
+
+## Analysis Workflow
+
+1. Identify whether the main issue is broad compilation volume or a few extreme hotspots.
+2. Parse timing-summary categories and rank the biggest compile contributors.
+3. Run the diagnostics script to surface type-checking hotspots:
+   ```bash
+   python3 scripts/diagnose_compilation.py \
+     --project App.xcodeproj \
+     --scheme MyApp \
+     --configuration Debug \
+     --destination "platform=iOS Simulator,name=iPhone 16" \
+     --threshold 100 \
+     --output-dir .build-benchmark
+   ```
+   This produces a ranked list of functions and expressions that exceed the millisecond threshold. Use the diagnostics artifact alongside source inspection to focus on the most expensive files first.
+4. Map the evidence to a concrete recommendation list.
+5. Separate code-level suggestions from project-level or module-level suggestions.
+
+## Apple-Derived Checks
+
+Look for these patterns first:
+
+- missing explicit type information in expensive expressions
+- complex chained or nested expressions that are hard to type-check
+- delegate properties typed as `AnyObject` instead of a concrete protocol
+- oversized Objective-C bridging headers or generated Swift-to-Objective-C surfaces
+- header imports that skip framework qualification and miss module-cache reuse
+- classes missing `final` that are never subclassed
+- overly broad access control (`public`/`open`) on internal-only symbols
+- monolithic SwiftUI `body` properties that should be decomposed into subviews
+- long method chains or closures without intermediate type annotations
+
+## Reporting Format
+
+For each recommendation, include:
+
+- observed evidence
+- likely affected file or module
+- expected wait-time impact (e.g. "Expected to reduce your clean build by ~2s" or "Reduces parallel compile work but unlikely to reduce build wait time")
+- confidence
+- whether approval is required before applying it
+
+If the evidence points to project configuration instead of source, hand off to [`xcode-project-analyzer`](../xcode-project-analyzer/SKILL.md) by reading its SKILL.md and applying its workflow to the same project context.
+
+## Preferred Tactics
+
+- Suggest ad hoc flag injection through the build command before recommending persistent build-setting changes.
+- Prefer narrowing giant view builders, closures, or result-builder expressions into smaller typed units.
+- Recommend explicit imports and protocol typing when they reduce compiler search space.
+- Call out when mixed-language boundaries are the real issue rather than Swift syntax alone.
+
+## Additional Resources
+
+- For the detailed audit checklist, see [references/code-compilation-checks.md](references/code-compilation-checks.md)
+- For the shared recommendation structure, see [references/recommendation-format.md](references/recommendation-format.md)
+- For source citations, see [references/build-optimization-sources.md](references/build-optimization-sources.md)

--- a/.agents/skills/xcode-compilation-analyzer/references/build-optimization-sources.md
+++ b/.agents/skills/xcode-compilation-analyzer/references/build-optimization-sources.md
@@ -1,0 +1,155 @@
+# Build Optimization Sources
+
+This file stores the external sources that the README and skill docs should cite consistently.
+
+## Apple: Improving the speed of incremental builds
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/improving-the-speed-of-incremental-builds>
+
+Key takeaways:
+
+- Measure first with `Build With Timing Summary` or `xcodebuild -showBuildTimingSummary`.
+- Accurate target dependencies improve correctness and parallelism.
+- Run scripts should declare inputs and outputs so Xcode can skip unnecessary work.
+- `.xcfilelist` files are appropriate when scripts have many inputs or outputs.
+- Custom frameworks and libraries benefit from module maps, typically by enabling `DEFINES_MODULE`.
+- Module reuse is strongest when related sources compile with consistent options.
+- Breaking monolithic targets into better-scoped modules can reduce unnecessary rebuilds.
+
+## Apple: Improving build efficiency with good coding practices
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/improving-build-efficiency-with-good-coding-practices>
+
+Key takeaways:
+
+- Use framework-qualified imports when module maps are available.
+- Keep Objective-C bridging surfaces narrow.
+- Prefer explicit type information when inference becomes expensive.
+- Use explicit delegate protocols instead of overly generic delegate types.
+- Simplify complex expressions that are hard for the compiler to type-check.
+
+## Apple: Building your project with explicit module dependencies
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/building-your-project-with-explicit-module-dependencies>
+
+Key takeaways:
+
+- Explicit module builds make module work visible in the build log and improve scheduling.
+- Repeated builds of the same module often point to avoidable module variants.
+- Inconsistent build options across targets can force duplicate module builds.
+- Timing summaries can reveal option drift that prevents module reuse.
+
+## SwiftLee: Build performance analysis for speeding up Xcode builds
+
+Source:
+
+- <https://www.avanderlee.com/optimization/analysing-build-performance-xcode/>
+
+Key takeaways:
+
+- Clean and incremental builds should both be measured because they reveal different problems.
+- Build Timeline and Build Timing Summary are practical starting points for build optimization.
+- Build scripts often produce large incremental-build wins when guarded correctly.
+- `-warn-long-function-bodies` and `-warn-long-expression-type-checking` help surface compile hotspots.
+- Typical debug and release build setting mismatches are worth auditing, especially in older projects.
+
+## Apple: Xcode Release Notes -- Compilation Caching
+
+Source:
+
+- Xcode Release Notes (149700201)
+
+Key takeaways:
+
+- Compilation caching is an opt-in feature for Swift and C-family languages.
+- It caches prior compilation results and reuses them when the same source inputs are recompiled.
+- Branch switching and clean builds benefit the most.
+- Can be enabled via the "Enable Compilation Caching" build setting or per-user project settings.
+
+## Apple: Demystify explicitly built modules (WWDC24)
+
+Source:
+
+- <https://developer.apple.com/videos/play/wwdc2024/10171/>
+
+Key takeaways:
+
+- Explains how explicitly built modules divide compilation into scan, module build, and source compile stages.
+- Unrelated modules build in parallel, improving CPU utilization.
+- Module variant duplication is a key bottleneck -- uniform compiler options across targets prevent it.
+- The build log shows each module as a discrete task, making it easier to diagnose scheduling issues.
+
+## Swift Compile-Time Best Practices
+
+Well-known Swift language patterns that reduce type-checker workload during compilation:
+
+- Mark classes `final` when they are not intended for subclassing. This eliminates dynamic dispatch overhead and allows the compiler to de-virtualize method calls.
+- Restrict access control to the narrowest useful scope (`private`, `fileprivate`). Fewer visible symbols reduce the compiler's search space during type resolution.
+- Prefer value types (`struct`, `enum`) over `class` when reference semantics are not needed. Value types are simpler for the compiler to reason about.
+- Break long method chains (`.map().flatMap().filter()`) into intermediate `let` bindings with explicit type annotations. Even simple-looking chains can take seconds to type-check.
+- Provide explicit return types on closures passed to generic functions, especially in SwiftUI result-builder contexts.
+- Decompose large SwiftUI `body` properties into smaller extracted subviews. Each subview narrows the scope of the result-builder expression the type-checker must resolve.
+
+## Bitrise: Demystifying Explicitly Built Modules for Xcode
+
+Source:
+
+- <https://bitrise.io/blog/post/demystifying-explicitly-built-modules-for-xcode>
+
+Key takeaways:
+
+- Explicit module builds give `xcodebuild` visibility into smaller compilation tasks for better parallelism.
+- Enabled by default for C/Objective-C in Xcode 16+; experimental for Swift.
+- Minimizing module variants by aligning build options is the primary optimization lever.
+- Some projects see regressions from dependency scanning overhead -- benchmark before and after.
+
+## Bitrise: Xcode Compilation Cache FAQ
+
+Source:
+
+- <https://docs.bitrise.io/en/bitrise-build-cache/build-cache-for-xcode/xcode-compilation-cache-faq.html>
+
+Key takeaways:
+
+- Granular caching is controlled by `SWIFT_ENABLE_COMPILE_CACHE` and `CLANG_ENABLE_COMPILE_CACHE`, under the umbrella `COMPILATION_CACHE_ENABLE_CACHING` setting.
+- Non-cacheable tasks include `CompileStoryboard`, `CompileXIB`, `CompileAssetCatalogVariant`, `PhaseScriptExecution`, `DataModelCompile`, `CopyPNGFile`, `GenerateDSYMFile`, and `Ld`.
+- SPM dependencies are not yet cacheable as of Xcode 26 beta.
+
+## RocketSim Docs: Build Insights
+
+Sources:
+
+- <https://www.rocketsim.app/docs/features/build-insights/build-insights/>
+- <https://www.rocketsim.app/docs/features/build-insights/team-build-insights/>
+
+Key takeaways:
+
+- RocketSim automatically tracks clean vs incremental builds over time without build scripts.
+- It reports build counts, duration trends, and percentile-based metrics such as p75 and p95.
+- Team Build Insights adds machine, Xcode, and macOS comparisons for cross-team visibility.
+- This repository is best positioned as the point-in-time analyze-and-improve toolkit, while RocketSim is the monitor-over-time companion.
+
+## Swift Forums: Slow incremental builds because of planning swift module
+
+Source:
+
+- <https://forums.swift.org/t/slow-incremental-builds-because-of-planning-swift-module/84803>
+
+Key takeaways:
+
+- "Planning Swift module" can dominate incremental builds (up to 30s per module), sometimes exceeding clean build time.
+- Replanning every module without scheduling compiles is a sign that build inputs are being modified unexpectedly (e.g., a misconfigured linter touching file timestamps).
+- Enable **Task Backtraces** (Xcode 16.4+: Scheme Editor > Build > Build Debugging) to see why each task re-ran in an incremental build.
+- Heavy Swift macro usage (e.g., TCA / swift-syntax) can cause trivial changes to cascade into near-full rebuilds.
+- `swift-syntax` builds universally (all architectures) when no prebuilt binary is available, adding significant overhead.
+- `SwiftEmitModule` can take 60s+ after a single-line change in large modules.
+- Asset catalog compilation is single-threaded per target; splitting assets into separate bundles across targets enables parallel compilation.
+- Multi-platform targets (e.g., adding watchOS) can cause SPM packages to build 3x (iOS arm64, iOS x86_64, watchOS arm64).
+- Zero-change incremental builds still incur ~10s of fixed overhead: compute dependencies, send project description, create build description, script phases, codesigning, and validation.
+- Codesigning and validation run even when output has not changed.

--- a/.agents/skills/xcode-compilation-analyzer/references/code-compilation-checks.md
+++ b/.agents/skills/xcode-compilation-analyzer/references/code-compilation-checks.md
@@ -1,0 +1,106 @@
+# Code Compilation Checks
+
+Use this reference when a build benchmark shows compilation dominating build time.
+
+## Primary Evidence Sources
+
+- `xcodebuild -showBuildTimingSummary`
+- build log compile tasks
+- `-warn-long-function-bodies`
+- `-warn-long-expression-type-checking`
+- `-debug-time-compilation` (per-file compile time ranking)
+- `-debug-time-function-bodies` (unfiltered per-function timing)
+- `-driver-time-compilation` (driver overhead)
+- `-stats-output-dir` (detailed compiler statistics as JSON)
+
+## Triage Questions
+
+1. Is one file or expression dominating compile time?
+2. Is the issue mostly Swift type-checking, mixed-language bridging, or header import churn?
+3. Are multiple files in the same module paying the same module-setup cost repeatedly?
+4. Is `SwiftEmitModule` disproportionately large for any target? If a single-line change triggers 60s+ of module emission, the target is likely too large or heavily macro-dependent.
+5. Does `Planning Swift module` dominate incremental builds? If modules are replanned but no compiles are scheduled, build inputs are being invalidated unexpectedly.
+
+## Checklist
+
+### Explicit typing
+
+- Add explicit property or local variable types when initialization expressions are complex.
+- Prefer intermediate typed variables over one giant inferred expression.
+
+### Expression simplification
+
+- Break long chains into smaller expressions.
+- Split complex result-builder code into smaller helpers or subviews.
+- Replace nested ternaries or overloaded generic chains with simpler steps.
+
+### Delegate typing
+
+- Avoid `AnyObject?` or overly generic delegate surfaces.
+- Prefer a named delegate protocol so the compiler has a narrower lookup space.
+
+### Objective-C and Swift bridging
+
+- Keep the Objective-C bridging header narrow.
+- Move internal-only Objective-C declarations out of the bridging surface.
+- Mark Swift members `private` when they do not need Objective-C visibility.
+
+### Framework-qualified imports
+
+- Prefer `#import <Framework/Header.h>` or module imports when a module map exists.
+- Watch for textual includes that defeat module-cache reuse.
+
+### Access control and dispatch optimization
+
+- Mark classes not intended for subclassing as `final`. This eliminates virtual dispatch overhead and lets the compiler de-virtualize method calls, reducing both compile and runtime cost.
+- Use `private` or `fileprivate` for properties and methods not used outside their declaration or file. Narrower visibility reduces the compiler's symbol search space.
+- Prefer `internal` (the default) over `public` unless the symbol genuinely crosses module boundaries. Wider access forces the compiler to consider more call sites.
+
+### Value types over reference types
+
+- Prefer `struct` and `enum` over `class` when reference semantics are not needed. Value types are simpler for the compiler to reason about and do not require vtable dispatch.
+- When a class exists solely to group data without identity semantics, convert it to a struct.
+
+### SwiftUI view decomposition
+
+- Extract subviews into dedicated `struct View` types instead of using `@ViewBuilder` helper properties. Separate structs reduce the type-checker scope per `body` property.
+- Break monolithic `body` properties (roughly 50+ lines) into smaller composed subviews. Large result-builder bodies are among the most expensive expressions to type-check.
+- Avoid deeply nested `Group`/`VStack`/`HStack` hierarchies within a single body.
+
+### Closure and chain patterns
+
+- Avoid long method chains like `.map().flatMap().filter().reduce()` without intermediate type annotations. Each link in the chain multiplies the type-checker's candidate set.
+- Break complex closures into named functions with explicit parameter and return types.
+- Add explicit return types to closures passed to generic functions so the compiler does not need to infer them from context.
+
+### Generic constraint complexity
+
+- Minimize deeply nested generic constraints (e.g., `where T: Collection, T.Element: Comparable, T.Element.SubSequence: ...`). Each additional constraint widens the compiler's search space.
+- Use type aliases to flatten complex generic stacks into readable names.
+- Prefer `some Protocol` (opaque return types) over unconstrained generics when the concrete type does not need to be visible to callers.
+
+### Module emission and planning overhead
+
+- Check `SwiftEmitModule` time in the Build Timing Summary. Large modules with many public symbols take longer to emit, and this cost is paid on every incremental build that touches the module.
+- If `SwiftEmitModule` exceeds compile time for the same target, the module's public API surface may be unnecessarily wide -- narrow access control or split the module.
+- Check `Planning Swift module` time. If it is significant in incremental builds, escalate to `xcode-project-analyzer` to investigate unexpected input invalidation or misconfigured scripts.
+
+### Precompiled and prefix headers
+
+- For mixed-language projects with large Objective-C codebases, verify that prefix headers are not bloated with unnecessary imports. Every import in a prefix header is parsed for every translation unit.
+- Migrate away from prefix headers toward explicit module imports where possible.
+
+## Recommendation Heuristics
+
+- High impact: repeated type-check warnings in a hot module, giant bridging headers, or a few files dominating compile time.
+- Medium impact: several moderate hotspots in result builders or overloaded generic code.
+- Low impact: isolated warnings without measurable benchmark impact.
+
+## Escalation Guidance
+
+Hand findings to `xcode-project-analyzer` when:
+
+- build scripts dominate instead of compilation
+- module reuse is blocked by project settings
+- target structure or explicit-module settings appear to be the real bottleneck
+- `Planning Swift module` overhead points to input invalidation or script-related causes rather than source complexity

--- a/.agents/skills/xcode-compilation-analyzer/references/recommendation-format.md
+++ b/.agents/skills/xcode-compilation-analyzer/references/recommendation-format.md
@@ -1,0 +1,85 @@
+# Recommendation Format
+
+All optimization skills should report recommendations in a shared structure so the orchestrator can merge and prioritize them cleanly.
+
+## Required Fields
+
+Each recommendation should include:
+
+- `title`
+- `wait_time_impact` -- plain-language statement of expected wall-clock impact, e.g. "Expected to reduce your clean build by ~3s", "Reduces parallel compile work but unlikely to reduce build wait time", or "Impact on wait time is uncertain -- re-benchmark to confirm"
+- `actionability` -- classifies how fixable the issue is from the project (see values below)
+- `category`
+- `observed_evidence`
+- `estimated_impact`
+- `confidence`
+- `approval_required`
+- `benchmark_verification_status`
+
+### Actionability Values
+
+Every recommendation must include an `actionability` classification:
+
+- `repo-local` -- Fix lives entirely in project files, source code, or local configuration. The developer can apply it without side effects outside the repo.
+- `package-manager` -- Requires CocoaPods or SPM configuration changes that may have broad side effects (e.g., linkage mode, dependency restructuring). These should be benchmarked before and after.
+- `xcode-behavior` -- Observed cost is driven by Xcode internals and is not suppressible from the project. Report the finding for awareness but do not promise a fix.
+- `upstream` -- Requires changes in a third-party dependency or external tool. The developer cannot fix it locally.
+
+## Suggested Optional Fields
+
+- `scope`
+- `affected_files`
+- `affected_targets`
+- `affected_packages`
+- `implementation_notes`
+- `risk_level`
+
+## JSON Example
+
+```json
+{
+  "recommendations": [
+    {
+      "title": "Guard a release-only symbol upload script",
+      "wait_time_impact": "Expected to reduce your incremental build by approximately 6 seconds.",
+      "actionability": "repo-local",
+      "category": "project",
+      "observed_evidence": [
+        "Incremental builds spend 6.3 seconds in a run script phase.",
+        "The script runs for Debug builds even though the output is only needed in Release."
+      ],
+      "estimated_impact": "High incremental-build improvement",
+      "confidence": "High",
+      "approval_required": true,
+      "benchmark_verification_status": "Not yet verified",
+      "scope": "Target build phase",
+      "risk_level": "Low"
+    }
+  ]
+}
+```
+
+## Markdown Rendering Guidance
+
+When rendering for human review, preserve the same field order:
+
+1. title
+2. wait-time impact
+3. actionability
+4. observed evidence
+5. estimated impact
+6. confidence
+7. approval required
+8. benchmark verification status
+
+That makes it easier for the developer to approve or reject specific items quickly.
+
+## Verification Status Values
+
+Recommended values:
+
+- `Not yet verified`
+- `Queued for verification`
+- `Verified improvement`
+- `No measurable improvement`
+- `Inconclusive due to benchmark noise`

--- a/.agents/skills/xcode-compilation-analyzer/scripts/diagnose_compilation.py
+++ b/.agents/skills/xcode-compilation-analyzer/scripts/diagnose_compilation.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+
+"""Run a single Xcode build with -Xfrontend diagnostics to find slow type-checking."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+_TYPECHECK_RE = re.compile(
+    r"^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+): warning: "
+    r"(?P<kind>instance method|global function|getter|type-check|expression) "
+    r"'?(?P<name>[^']*?)'?\s+took\s+(?P<ms>\d+)ms\s+to\s+type-check"
+)
+
+_EXPRESSION_RE = re.compile(
+    r"^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+): warning: "
+    r"expression took\s+(?P<ms>\d+)ms\s+to\s+type-check"
+)
+
+_FILE_TIME_RE = re.compile(
+    r"^\s*(?P<seconds>\d+(?:\.\d+)?)\s+seconds\s+.*\s+compiling\s+(?P<file>\S+)"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run an Xcode build with -Xfrontend type-checking diagnostics."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--workspace", help="Path to the .xcworkspace file")
+    group.add_argument("--project", help="Path to the .xcodeproj file")
+    parser.add_argument("--scheme", required=True, help="Scheme to build")
+    parser.add_argument("--configuration", default="Debug", help="Build configuration")
+    parser.add_argument("--destination", help="xcodebuild destination string")
+    parser.add_argument("--derived-data-path", help="DerivedData path override")
+    parser.add_argument("--output-dir", default=".build-benchmark", help="Output directory")
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=100,
+        help="Millisecond threshold for -warn-long-function-bodies and "
+        "-warn-long-expression-type-checking (default: 100)",
+    )
+    parser.add_argument("--skip-clean", action="store_true", help="Skip clean before build")
+    parser.add_argument(
+        "--per-file-timing",
+        action="store_true",
+        help="Add -Xfrontend -debug-time-compilation to report per-file compile times.",
+    )
+    parser.add_argument(
+        "--stats-output",
+        action="store_true",
+        help="Add -Xfrontend -stats-output-dir to collect detailed compiler statistics.",
+    )
+    parser.add_argument(
+        "--extra-arg",
+        action="append",
+        default=[],
+        help="Additional xcodebuild argument. Can be passed multiple times.",
+    )
+    return parser.parse_args()
+
+
+def command_base(args: argparse.Namespace) -> List[str]:
+    command = ["xcodebuild"]
+    if args.workspace:
+        command.extend(["-workspace", args.workspace])
+    if args.project:
+        command.extend(["-project", args.project])
+    command.extend(["-scheme", args.scheme, "-configuration", args.configuration])
+    if args.destination:
+        command.extend(["-destination", args.destination])
+    if args.derived_data_path:
+        command.extend(["-derivedDataPath", args.derived_data_path])
+    command.extend(args.extra_arg)
+    return command
+
+
+def parse_diagnostics(output: str) -> List[Dict]:
+    """Extract type-checking warnings from xcodebuild output."""
+    warnings: List[Dict] = []
+    seen = set()
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        match = _TYPECHECK_RE.match(line)
+        if match:
+            key = (match.group("file"), match.group("line"), match.group("col"), "function-body")
+            if key in seen:
+                continue
+            seen.add(key)
+            warnings.append(
+                {
+                    "file": match.group("file"),
+                    "line": int(match.group("line")),
+                    "column": int(match.group("col")),
+                    "duration_ms": int(match.group("ms")),
+                    "kind": "function-body",
+                    "name": match.group("name"),
+                }
+            )
+            continue
+        match = _EXPRESSION_RE.match(line)
+        if match:
+            key = (match.group("file"), match.group("line"), match.group("col"), "expression")
+            if key in seen:
+                continue
+            seen.add(key)
+            warnings.append(
+                {
+                    "file": match.group("file"),
+                    "line": int(match.group("line")),
+                    "column": int(match.group("col")),
+                    "duration_ms": int(match.group("ms")),
+                    "kind": "expression",
+                    "name": "",
+                }
+            )
+    warnings.sort(key=lambda w: w["duration_ms"], reverse=True)
+    return warnings
+
+
+def parse_file_timings(output: str) -> List[Dict]:
+    """Extract per-file compile times from -debug-time-compilation output."""
+    timings: List[Dict] = []
+    seen = set()
+    for raw_line in output.splitlines():
+        match = _FILE_TIME_RE.match(raw_line.strip())
+        if match:
+            filepath = match.group("file")
+            if filepath in seen:
+                continue
+            seen.add(filepath)
+            timings.append(
+                {
+                    "file": filepath,
+                    "duration_seconds": float(match.group("seconds")),
+                }
+            )
+    timings.sort(key=lambda t: t["duration_seconds"], reverse=True)
+    return timings
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    scheme_slug = args.scheme.replace(" ", "-").lower()
+    artifact_stem = f"{timestamp}-{scheme_slug}"
+    base = command_base(args)
+
+    if not args.skip_clean:
+        print("Cleaning build products...")
+        clean = subprocess.run([*base, "clean"], capture_output=True, text=True)
+        if clean.returncode != 0:
+            sys.stderr.write(clean.stdout + clean.stderr)
+            return clean.returncode
+
+    threshold = str(args.threshold)
+    swift_flags = (
+        f"$(inherited) -Xfrontend -warn-long-function-bodies={threshold} "
+        f"-Xfrontend -warn-long-expression-type-checking={threshold}"
+    )
+    if args.per_file_timing:
+        swift_flags += " -Xfrontend -debug-time-compilation"
+
+    stats_dir: Optional[Path] = None
+    if args.stats_output:
+        stats_dir = output_dir / f"{artifact_stem}-stats"
+        stats_dir.mkdir(parents=True, exist_ok=True)
+        swift_flags += f" -Xfrontend -stats-output-dir -Xfrontend {stats_dir}"
+
+    build_command = [
+        *base,
+        "build",
+        "-showBuildTimingSummary",
+        f"OTHER_SWIFT_FLAGS={swift_flags}",
+    ]
+
+    extras = []
+    if args.per_file_timing:
+        extras.append("per-file timing")
+    if args.stats_output:
+        extras.append("stats output")
+    extras_label = f" + {', '.join(extras)}" if extras else ""
+    print(f"Building with type-check threshold {threshold}ms{extras_label}...")
+    started = time.perf_counter()
+    result = subprocess.run(build_command, capture_output=True, text=True)
+    elapsed = round(time.perf_counter() - started, 3)
+
+    combined_output = result.stdout + result.stderr
+    log_path = output_dir / f"{artifact_stem}-diagnostics.log"
+    log_path.write_text(combined_output)
+
+    warnings = parse_diagnostics(combined_output)
+
+    file_timings: Optional[List[Dict]] = None
+    if args.per_file_timing:
+        file_timings = parse_file_timings(combined_output)
+
+    artifact = {
+        "schema_version": "1.0.0",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "type": "compilation-diagnostics",
+        "build": {
+            "entrypoint": "workspace" if args.workspace else "project",
+            "path": args.workspace or args.project,
+            "scheme": args.scheme,
+            "configuration": args.configuration,
+            "destination": args.destination or "",
+        },
+        "threshold_ms": args.threshold,
+        "build_duration_seconds": elapsed,
+        "build_success": result.returncode == 0,
+        "raw_log_path": str(log_path),
+        "warnings": warnings,
+        "summary": {
+            "total_warnings": len(warnings),
+            "function_body_warnings": sum(1 for w in warnings if w["kind"] == "function-body"),
+            "expression_warnings": sum(1 for w in warnings if w["kind"] == "expression"),
+            "slowest_ms": warnings[0]["duration_ms"] if warnings else 0,
+        },
+    }
+
+    if file_timings is not None:
+        artifact["per_file_timings"] = file_timings
+    if stats_dir is not None:
+        artifact["stats_dir"] = str(stats_dir)
+
+    artifact_path = output_dir / f"{artifact_stem}-diagnostics.json"
+    artifact_path.write_text(json.dumps(artifact, indent=2) + "\n")
+
+    print(f"\nSaved diagnostics artifact: {artifact_path}")
+    print(f"Build {'succeeded' if result.returncode == 0 else 'failed'} in {elapsed}s")
+    print(f"Found {len(warnings)} type-check warnings above {threshold}ms threshold\n")
+
+    if warnings:
+        print(f"{'Duration':>10}  {'Kind':<15}  {'Location'}")
+        print(f"{'--------':>10}  {'----':<15}  {'--------'}")
+        for w in warnings[:20]:
+            loc = f"{w['file']}:{w['line']}:{w['column']}"
+            label = w["name"] if w["name"] else "(expression)"
+            print(f"{w['duration_ms']:>8}ms  {w['kind']:<15}  {loc}  {label}")
+        if len(warnings) > 20:
+            print(f"\n  ... and {len(warnings) - 20} more (see {artifact_path})")
+    else:
+        print("No type-checking hotspots found above threshold.")
+
+    if file_timings:
+        print(f"\nPer-file compile times (top 20):\n")
+        print(f"{'Duration':>12}  {'File'}")
+        print(f"{'--------':>12}  {'----'}")
+        for t in file_timings[:20]:
+            print(f"{t['duration_seconds']:>10.3f}s  {t['file']}")
+        if len(file_timings) > 20:
+            print(f"\n  ... and {len(file_timings) - 20} more (see {artifact_path})")
+
+    if stats_dir is not None:
+        stat_files = list(stats_dir.glob("*.json"))
+        print(f"\nCompiler statistics: {len(stat_files)} files written to {stats_dir}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/xcode-project-analyzer/SKILL.md
+++ b/.agents/skills/xcode-project-analyzer/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: xcode-project-analyzer
+description: Audit Xcode project configuration, build settings, scheme behavior, and script phases to find build-time improvements with explicit approval gates. Use when a developer wants project-level build analysis, slow incremental builds, guidance on target dependencies, build settings review, run script phase analysis, parallelization improvements, or module-map and DEFINES_MODULE configuration.
+---
+
+# Xcode Project Analyzer
+
+Use this skill for project- and target-level build inefficiencies that are unlikely to be solved by source edits alone.
+
+## Core Rules
+
+- Recommendation-first by default.
+- Require explicit approval before changing project files, schemes, or build settings.
+- Prefer measured findings tied to timing summaries, build logs, or project configuration evidence.
+- Distinguish debug-only pain from release-only pain.
+
+## What To Review
+
+- scheme build order and target dependencies
+- debug vs release build settings against the [build settings best practices](references/build-settings-best-practices.md)
+- run script phases and dependency-analysis settings
+- derived-data churn or obviously invalidating custom steps
+- opportunities for parallelization
+- explicit module dependency settings and module-map readiness
+- "Planning Swift module" time in the Build Timing Summary -- if it dominates incremental builds, suspect unexpected input modification or macro-related invalidation
+- asset catalog compilation time, especially in targets with large or numerous catalogs
+- `ExtractAppIntentsMetadata` time in the Build Timing Summary -- if this phase consumes significant time, record it as `xcode-behavior` (report the cost and impact, but do not suggest a repo-local optimization unless there is explicit Apple guidance)
+- zero-change build overhead -- if a no-op rebuild exceeds a few seconds, investigate fixed-cost phases (script execution, codesign, validation, CopySwiftLibs)
+- CocoaPods usage -- if a `Podfile` or `Pods.xcodeproj` exists, CocoaPods is deprecated; recommend migrating to SPM and do not attempt CocoaPods-specific optimizations (see [project-audit-checks.md](references/project-audit-checks.md))
+- Task Backtraces (Xcode 16.4+: Scheme Editor > Build > Build Debugging) to diagnose why tasks re-run unexpectedly in incremental builds
+
+## Build Settings Best Practices Audit
+
+Every project audit should include a build settings checklist comparing the project's Debug and Release configurations against the recommended values in [build-settings-best-practices.md](references/build-settings-best-practices.md). Present results using checkmark/cross indicators (`[x]`/`[ ]`). The scope is strictly build performance -- do not flag language-migration settings like `SWIFT_STRICT_CONCURRENCY` or `SWIFT_UPCOMING_FEATURE_*`.
+
+## Apple-Derived Checks
+
+Review these items in every audit:
+
+- target dependencies are accurate and not missing or inflated
+- schemes build in `Dependency Order`
+- run scripts declare inputs and outputs
+- `.xcfilelist` files are used when scripts have many inputs or outputs
+- `DEFINES_MODULE` is enabled where custom frameworks or libraries should expose module maps
+- headers are self-contained enough for module-map use
+- explicit module dependency settings are consistent for targets that should share modules
+
+## Typical Wins
+
+- skip debug-time scripts that only matter in release
+- add missing script guards or dependency-analysis metadata
+- remove accidental serial bottlenecks in schemes
+- align build settings that cause unnecessary module variants
+- fix stale project structure that forces broader rebuilds than necessary
+- identify linters or formatters that touch file timestamps without changing content, silently invalidating build inputs and forcing module replanning
+- split large asset catalogs into separate resource bundles across targets to parallelize compilation
+- use Task Backtraces to pinpoint the exact input change that triggers unnecessary incremental work
+
+## Reporting Format
+
+For each issue, include:
+
+- evidence
+- likely scope
+- why it affects clean builds, incremental builds, or both
+- estimated impact
+- approval requirement
+
+If the evidence points to package graph or build plugins, hand off to [`spm-build-analysis`](../spm-build-analysis/SKILL.md) by reading its SKILL.md and applying its workflow to the same project context.
+
+## Additional Resources
+
+- For the detailed audit checklist, see [references/project-audit-checks.md](references/project-audit-checks.md)
+- For build settings best practices, see [references/build-settings-best-practices.md](references/build-settings-best-practices.md)
+- For the shared recommendation structure, see [references/recommendation-format.md](references/recommendation-format.md)
+- For Apple-aligned source summaries, see [references/build-optimization-sources.md](references/build-optimization-sources.md)

--- a/.agents/skills/xcode-project-analyzer/references/build-optimization-sources.md
+++ b/.agents/skills/xcode-project-analyzer/references/build-optimization-sources.md
@@ -1,0 +1,155 @@
+# Build Optimization Sources
+
+This file stores the external sources that the README and skill docs should cite consistently.
+
+## Apple: Improving the speed of incremental builds
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/improving-the-speed-of-incremental-builds>
+
+Key takeaways:
+
+- Measure first with `Build With Timing Summary` or `xcodebuild -showBuildTimingSummary`.
+- Accurate target dependencies improve correctness and parallelism.
+- Run scripts should declare inputs and outputs so Xcode can skip unnecessary work.
+- `.xcfilelist` files are appropriate when scripts have many inputs or outputs.
+- Custom frameworks and libraries benefit from module maps, typically by enabling `DEFINES_MODULE`.
+- Module reuse is strongest when related sources compile with consistent options.
+- Breaking monolithic targets into better-scoped modules can reduce unnecessary rebuilds.
+
+## Apple: Improving build efficiency with good coding practices
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/improving-build-efficiency-with-good-coding-practices>
+
+Key takeaways:
+
+- Use framework-qualified imports when module maps are available.
+- Keep Objective-C bridging surfaces narrow.
+- Prefer explicit type information when inference becomes expensive.
+- Use explicit delegate protocols instead of overly generic delegate types.
+- Simplify complex expressions that are hard for the compiler to type-check.
+
+## Apple: Building your project with explicit module dependencies
+
+Source:
+
+- <https://developer.apple.com/documentation/xcode/building-your-project-with-explicit-module-dependencies>
+
+Key takeaways:
+
+- Explicit module builds make module work visible in the build log and improve scheduling.
+- Repeated builds of the same module often point to avoidable module variants.
+- Inconsistent build options across targets can force duplicate module builds.
+- Timing summaries can reveal option drift that prevents module reuse.
+
+## SwiftLee: Build performance analysis for speeding up Xcode builds
+
+Source:
+
+- <https://www.avanderlee.com/optimization/analysing-build-performance-xcode/>
+
+Key takeaways:
+
+- Clean and incremental builds should both be measured because they reveal different problems.
+- Build Timeline and Build Timing Summary are practical starting points for build optimization.
+- Build scripts often produce large incremental-build wins when guarded correctly.
+- `-warn-long-function-bodies` and `-warn-long-expression-type-checking` help surface compile hotspots.
+- Typical debug and release build setting mismatches are worth auditing, especially in older projects.
+
+## Apple: Xcode Release Notes -- Compilation Caching
+
+Source:
+
+- Xcode Release Notes (149700201)
+
+Key takeaways:
+
+- Compilation caching is an opt-in feature for Swift and C-family languages.
+- It caches prior compilation results and reuses them when the same source inputs are recompiled.
+- Branch switching and clean builds benefit the most.
+- Can be enabled via the "Enable Compilation Caching" build setting or per-user project settings.
+
+## Apple: Demystify explicitly built modules (WWDC24)
+
+Source:
+
+- <https://developer.apple.com/videos/play/wwdc2024/10171/>
+
+Key takeaways:
+
+- Explains how explicitly built modules divide compilation into scan, module build, and source compile stages.
+- Unrelated modules build in parallel, improving CPU utilization.
+- Module variant duplication is a key bottleneck -- uniform compiler options across targets prevent it.
+- The build log shows each module as a discrete task, making it easier to diagnose scheduling issues.
+
+## Swift Compile-Time Best Practices
+
+Well-known Swift language patterns that reduce type-checker workload during compilation:
+
+- Mark classes `final` when they are not intended for subclassing. This eliminates dynamic dispatch overhead and allows the compiler to de-virtualize method calls.
+- Restrict access control to the narrowest useful scope (`private`, `fileprivate`). Fewer visible symbols reduce the compiler's search space during type resolution.
+- Prefer value types (`struct`, `enum`) over `class` when reference semantics are not needed. Value types are simpler for the compiler to reason about.
+- Break long method chains (`.map().flatMap().filter()`) into intermediate `let` bindings with explicit type annotations. Even simple-looking chains can take seconds to type-check.
+- Provide explicit return types on closures passed to generic functions, especially in SwiftUI result-builder contexts.
+- Decompose large SwiftUI `body` properties into smaller extracted subviews. Each subview narrows the scope of the result-builder expression the type-checker must resolve.
+
+## Bitrise: Demystifying Explicitly Built Modules for Xcode
+
+Source:
+
+- <https://bitrise.io/blog/post/demystifying-explicitly-built-modules-for-xcode>
+
+Key takeaways:
+
+- Explicit module builds give `xcodebuild` visibility into smaller compilation tasks for better parallelism.
+- Enabled by default for C/Objective-C in Xcode 16+; experimental for Swift.
+- Minimizing module variants by aligning build options is the primary optimization lever.
+- Some projects see regressions from dependency scanning overhead -- benchmark before and after.
+
+## Bitrise: Xcode Compilation Cache FAQ
+
+Source:
+
+- <https://docs.bitrise.io/en/bitrise-build-cache/build-cache-for-xcode/xcode-compilation-cache-faq.html>
+
+Key takeaways:
+
+- Granular caching is controlled by `SWIFT_ENABLE_COMPILE_CACHE` and `CLANG_ENABLE_COMPILE_CACHE`, under the umbrella `COMPILATION_CACHE_ENABLE_CACHING` setting.
+- Non-cacheable tasks include `CompileStoryboard`, `CompileXIB`, `CompileAssetCatalogVariant`, `PhaseScriptExecution`, `DataModelCompile`, `CopyPNGFile`, `GenerateDSYMFile`, and `Ld`.
+- SPM dependencies are not yet cacheable as of Xcode 26 beta.
+
+## RocketSim Docs: Build Insights
+
+Sources:
+
+- <https://www.rocketsim.app/docs/features/build-insights/build-insights/>
+- <https://www.rocketsim.app/docs/features/build-insights/team-build-insights/>
+
+Key takeaways:
+
+- RocketSim automatically tracks clean vs incremental builds over time without build scripts.
+- It reports build counts, duration trends, and percentile-based metrics such as p75 and p95.
+- Team Build Insights adds machine, Xcode, and macOS comparisons for cross-team visibility.
+- This repository is best positioned as the point-in-time analyze-and-improve toolkit, while RocketSim is the monitor-over-time companion.
+
+## Swift Forums: Slow incremental builds because of planning swift module
+
+Source:
+
+- <https://forums.swift.org/t/slow-incremental-builds-because-of-planning-swift-module/84803>
+
+Key takeaways:
+
+- "Planning Swift module" can dominate incremental builds (up to 30s per module), sometimes exceeding clean build time.
+- Replanning every module without scheduling compiles is a sign that build inputs are being modified unexpectedly (e.g., a misconfigured linter touching file timestamps).
+- Enable **Task Backtraces** (Xcode 16.4+: Scheme Editor > Build > Build Debugging) to see why each task re-ran in an incremental build.
+- Heavy Swift macro usage (e.g., TCA / swift-syntax) can cause trivial changes to cascade into near-full rebuilds.
+- `swift-syntax` builds universally (all architectures) when no prebuilt binary is available, adding significant overhead.
+- `SwiftEmitModule` can take 60s+ after a single-line change in large modules.
+- Asset catalog compilation is single-threaded per target; splitting assets into separate bundles across targets enables parallel compilation.
+- Multi-platform targets (e.g., adding watchOS) can cause SPM packages to build 3x (iOS arm64, iOS x86_64, watchOS arm64).
+- Zero-change incremental builds still incur ~10s of fixed overhead: compute dependencies, send project description, create build description, script phases, codesigning, and validation.
+- Codesigning and validation run even when output has not changed.

--- a/.agents/skills/xcode-project-analyzer/references/build-settings-best-practices.md
+++ b/.agents/skills/xcode-project-analyzer/references/build-settings-best-practices.md
@@ -1,0 +1,216 @@
+# Build Settings Best Practices
+
+This reference lists Xcode build settings that affect build performance. Use it to audit a project and produce a pass/fail checklist.
+
+The scope is strictly **build performance**. Do not flag language-migration settings like `SWIFT_STRICT_CONCURRENCY` or `SWIFT_UPCOMING_FEATURE_*` -- those are developer adoption choices unrelated to build speed.
+
+## How To Read This Reference
+
+Each setting includes:
+
+- **Setting name** and the Xcode build-settings key
+- **Recommended value** for Debug and Release
+- **Why it matters** for build time
+- **Risk** of changing it
+
+Use checkmark and cross indicators when reporting:
+
+- `[x]` -- setting matches the recommended value
+- `[ ]` -- setting does not match; include the actual value and the expected value
+
+## Debug Configuration
+
+These settings optimize for fast iteration during development.
+
+### Compilation Mode
+
+- **Key:** `SWIFT_COMPILATION_MODE`
+- **Recommended:** `singlefile` (Xcode UI: "Incremental"; or unset -- Xcode defaults to singlefile for Debug)
+- **Why:** Single-file mode recompiles only changed files. `wholemodule` recompiles the entire target on every change.
+- **Risk:** Low
+
+### Swift Optimization Level
+
+- **Key:** `SWIFT_OPTIMIZATION_LEVEL`
+- **Recommended:** `-Onone`
+- **Why:** Optimization passes add significant compile time. Debug builds do not benefit from runtime speed improvements.
+- **Risk:** Low
+
+### GCC Optimization Level
+
+- **Key:** `GCC_OPTIMIZATION_LEVEL`
+- **Recommended:** `0`
+- **Why:** Same rationale as Swift optimization level, but for C/C++/Objective-C sources.
+- **Risk:** Low
+
+### Build Active Architecture Only
+
+- **Key:** `ONLY_ACTIVE_ARCH` (`BUILD_ACTIVE_ARCHITECTURE_ONLY`)
+- **Recommended:** `YES`
+- **Why:** Building all architectures doubles or triples compile and link time for no debug benefit.
+- **Risk:** Low
+
+### Debug Information Format
+
+- **Key:** `DEBUG_INFORMATION_FORMAT`
+- **Recommended:** `dwarf`
+- **Why:** `dwarf-with-dsym` generates a separate dSYM bundle which adds overhead. Plain `dwarf` embeds debug info directly in the binary, which is sufficient for local debugging.
+- **Risk:** Low
+
+### Enable Testability
+
+- **Key:** `ENABLE_TESTABILITY`
+- **Recommended:** `YES`
+- **Why:** Required for `@testable import`. Adds minor overhead by exporting internal symbols, but this is expected during development.
+- **Risk:** Low
+
+### Active Compilation Conditions
+
+- **Key:** `SWIFT_ACTIVE_COMPILATION_CONDITIONS`
+- **Recommended:** Should include `DEBUG`
+- **Why:** Guards conditional compilation blocks (e.g., `#if DEBUG`) and ensures debug-only code paths are included.
+- **Risk:** Low
+
+### Eager Linking
+
+- **Key:** `EAGER_LINKING`
+- **Recommended:** `YES`
+- **Why:** Allows the linker to start work before all compilation tasks finish, reducing wall-clock build time. Particularly effective for Debug builds where link time is a meaningful fraction of total build time.
+- **Risk:** Low
+
+## Release Configuration
+
+These settings optimize for production builds.
+
+### Compilation Mode
+
+- **Key:** `SWIFT_COMPILATION_MODE`
+- **Recommended:** `wholemodule`
+- **Why:** Whole-module optimization produces faster runtime code. Build time is secondary for release.
+- **Risk:** Low
+
+### Swift Optimization Level
+
+- **Key:** `SWIFT_OPTIMIZATION_LEVEL`
+- **Recommended:** `-O` or `-Osize`
+- **Why:** Produces optimized binaries. `-Osize` trades some speed for smaller binary size.
+- **Risk:** Low
+
+### GCC Optimization Level
+
+- **Key:** `GCC_OPTIMIZATION_LEVEL`
+- **Recommended:** `s`
+- **Why:** Optimizes C/C++/Objective-C for size, matching the typical release expectation.
+- **Risk:** Low
+
+### Build Active Architecture Only
+
+- **Key:** `ONLY_ACTIVE_ARCH`
+- **Recommended:** `NO`
+- **Why:** Release builds must include all supported architectures for distribution.
+- **Risk:** Low
+
+### Debug Information Format
+
+- **Key:** `DEBUG_INFORMATION_FORMAT`
+- **Recommended:** `dwarf-with-dsym`
+- **Why:** dSYM bundles are required for crash symbolication in production.
+- **Risk:** Low
+
+### Enable Testability
+
+- **Key:** `ENABLE_TESTABILITY`
+- **Recommended:** `NO`
+- **Why:** Removes internal-symbol export overhead from release builds. Testing should use Debug configuration.
+- **Risk:** Low
+
+## General (All Configurations)
+
+### Compilation Caching
+
+- **Key:** `COMPILATION_CACHE_ENABLE_CACHING`
+- **Recommended:** `YES`
+- **Why:** Caches compilation results for Swift and C-family sources so repeated compilations of the same inputs are served from cache. The biggest wins come from branch switching and clean builds where source files are recompiled unchanged. This is an opt-in feature. The umbrella setting controls both `SWIFT_ENABLE_COMPILE_CACHE` and `CLANG_ENABLE_COMPILE_CACHE` under the hood; those can be toggled independently if needed.
+- **Measurement:** Measured 5-14% faster clean builds across tested projects (87 to 1,991 Swift files). The benefit compounds in real developer workflows where the cache persists between builds -- branch switching, pulling changes, and CI with persistent DerivedData -- though the exact savings depend on how many files change between builds.
+- **Risk:** Low -- can also be enabled via per-user project settings so it does not need to be committed to the shared project file.
+
+### Integrated Swift Driver
+
+- **Key:** `SWIFT_USE_INTEGRATED_DRIVER`
+- **Recommended:** `YES`
+- **Why:** Uses the integrated Swift driver which runs inside the build system process, eliminating inter-process overhead for compilation scheduling. Enabled by default in modern Xcode but worth verifying in migrated projects.
+- **Risk:** Low
+
+### Clang Module Compilation
+
+- **Key:** `CLANG_ENABLE_MODULES`
+- **Recommended:** `YES`
+- **Why:** Enables Clang module compilation for C/Objective-C sources, caching module maps on disk instead of reprocessing headers on every import. Eliminates redundant header parsing across translation units.
+- **Risk:** Low
+
+### Explicit Module Builds
+
+- **Key:** `SWIFT_ENABLE_EXPLICIT_MODULES` (C/ObjC enabled by default in Xcode 16+; for Swift use `_EXPERIMENTAL_SWIFT_EXPLICIT_MODULES`)
+- **Recommended:** Evaluate per-project
+- **Why:** Makes module compilation visible to the build system as discrete tasks, improving parallelism and scheduling. Reduces redundant module rebuilds by making dependency edges explicit. Some projects see regressions due to the overhead of dependency scanning, so benchmark before and after enabling.
+- **Risk:** Medium -- test thoroughly; currently experimental for Swift targets.
+
+## Cross-Target Consistency
+
+These checks find settings differences between targets that cause redundant build work.
+
+### Project-Level vs Target-Level Overrides
+
+Build-affecting settings should be set at the project level unless a target has a specific reason to override. Unnecessary per-target overrides cause confusion and can silently create module variants.
+
+Settings to check for project-level consistency:
+
+- `SWIFT_COMPILATION_MODE`
+- `SWIFT_OPTIMIZATION_LEVEL`
+- `ONLY_ACTIVE_ARCH`
+- `DEBUG_INFORMATION_FORMAT`
+
+### Module Variant Duplication
+
+When multiple targets import the same SPM package but compile with different Swift compiler options, the build system produces separate module variants for each combination. This inflates `SwiftEmitModule` task counts.
+
+Check for drift in:
+
+- `SWIFT_OPTIMIZATION_LEVEL`
+- `SWIFT_COMPILATION_MODE`
+- `OTHER_SWIFT_FLAGS`
+- Target-level build settings that override project defaults
+
+### Out of Scope
+
+Do **not** flag the following as build-performance issues:
+
+- `SWIFT_STRICT_CONCURRENCY` -- language migration choice
+- `SWIFT_UPCOMING_FEATURE_*` -- language migration choice
+- `SWIFT_APPROACHABLE_CONCURRENCY` -- language migration choice
+- `SWIFT_ACTIVE_COMPILATION_CONDITIONS` values beyond `DEBUG` (e.g., `WIDGETS`, `APPCLIP`) -- intentional per-target customization
+
+## Checklist Output Format
+
+When reporting results, use this structure:
+
+```markdown
+### Debug Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `singlefile` (recommended: `singlefile`)
+- [ ] `DEBUG_INFORMATION_FORMAT`: `dwarf-with-dsym` (recommended: `dwarf`)
+- [x] `SWIFT_OPTIMIZATION_LEVEL`: `-Onone` (recommended: `-Onone`)
+...
+
+### Release Configuration
+- [x] `SWIFT_COMPILATION_MODE`: `wholemodule` (recommended: `wholemodule`)
+...
+
+### General (All Configurations)
+- [ ] `COMPILATION_CACHE_ENABLE_CACHING`: `NO` (recommended: `YES`)
+...
+
+### Cross-Target Consistency
+- [x] All targets inherit `SWIFT_OPTIMIZATION_LEVEL` from project level
+- [ ] `OTHER_SWIFT_FLAGS` differs between Stock Analyzer and StockAnalyzerClip
+...
+```

--- a/.agents/skills/xcode-project-analyzer/references/project-audit-checks.md
+++ b/.agents/skills/xcode-project-analyzer/references/project-audit-checks.md
@@ -1,0 +1,101 @@
+# Project Audit Checks
+
+Use this reference when reviewing build-system configuration rather than source-level compile behavior.
+
+## Target And Scheme Checks
+
+- Confirm target dependencies are explicit and accurate.
+- Remove dependencies that no longer reflect real build requirements.
+- Ensure the scheme builds targets in `Dependency Order`.
+- Look for oversized or monolithic targets that block parallel work.
+
+## Build Script Checks
+
+- Does each script need to run during incremental builds?
+- Are input and output files declared?
+- Should inputs and outputs be moved into `.xcfilelist` files?
+- Can the script skip debug builds, simulator builds, or unchanged inputs?
+- Would the script become parallelizable if dependency analysis were declared correctly?
+- Could a misconfigured linter or formatter script be touching file timestamps without changing content? This silently invalidates build inputs and forces replanning of every module.
+
+## Build Planning And Incremental Overhead Checks
+
+- Check whether "Planning Swift module" appears as a significant category in the Build Timing Summary. In projects with many modules this step can take up to 30s per module, sometimes exceeding clean build time.
+- If modules are replanned but no compiles are scheduled, suspect unexpected input modification (see Build Script Checks above).
+- Enable **Task Backtraces** (Xcode 16.4+) to diagnose why tasks re-run in incremental builds: Scheme Editor > Build tab > Build Debugging > enable "Task Backtraces." Expanding tasks in the build log will show a backtrace explaining what input change triggered the re-run.
+- Measure zero-change incremental build time as a baseline. Even with no source changes, builds incur fixed overhead: compute dependencies, send project description to build service, create build description, run script phases, codesign, and validate. If this baseline exceeds a few seconds, investigate each contributor.
+- Check whether codesigning and validation run on every build even when the build output has not changed.
+
+## Zero-Change Build Overhead Analysis
+
+When a zero-change build (no edits, immediate rebuild) takes more than a few seconds, the overhead comes from fixed-cost phases rather than compilation. Investigate these categories in the Build Timing Summary:
+
+- **PhaseScriptExecution**: Script phases with `alwaysOutOfDate = 1` or missing input/output declarations run on every build regardless of changes. Linters, formatters, and upload scripts are common offenders.
+- **CodeSign**: Codesigning runs on every build for the app target and any embedded frameworks. Time scales with the number of signed binaries.
+- **ValidateEmbeddedBinary**: Validates embedded binaries against the host app's provisioning profile. Runs unconditionally.
+- **CopySwiftLibs**: Copies Swift standard libraries into the app bundle. Runs even when nothing changed.
+- **RegisterWithLaunchServices**: Registers the built app with Launch Services. Fast but present in every build.
+- **ProcessInfoPlistFile**: Re-processes Info.plist files. Time scales with the number of targets.
+- **ExtractAppIntentsMetadata**: Extracts App Intents metadata from all targets. This phase is driven by Xcode and runs across all targets including CocoaPods and SwiftPM dependencies, not just first-party targets. If the project does not use App Intents, the work is unnecessary overhead, but it is not cleanly suppressible from project-level build settings alone. Classify findings about this phase as `xcode-behavior` actionability -- report the measured cost for awareness but do not promise a repo-local fix.
+
+A zero-change build above 5 seconds on Apple Silicon typically indicates script phase overhead or an excessive number of targets requiring codesign and validation passes.
+
+## Asset Catalog Checks
+
+- Asset catalog compilation (`CompileAssetCatalog`) is single-threaded per target. Multiple catalogs within the same target compile sequentially in a single process.
+- If asset catalog compilation appears as a significant timing category, recommend splitting assets into separate resource bundles across separate targets to enable parallel compilation.
+- Asset catalog compilation is not cacheable by the Xcode compilation cache (`CompileAssetCatalogVariant` is non-cacheable).
+- Check whether asset catalogs rebuild during incremental builds even when no assets changed. If so, investigate whether build inputs for the catalog step are being invalidated unexpectedly.
+
+## Build Setting Checks
+
+Audit project-level and target-level settings against the [build settings best practices](build-settings-best-practices.md). Present results as a checklist with `[x]`/`[ ]` indicators.
+
+Key settings to verify:
+
+- `SWIFT_COMPILATION_MODE` -- `singlefile` for Debug, `wholemodule` for Release
+- `SWIFT_OPTIMIZATION_LEVEL` -- `-Onone` for Debug, `-O` or `-Osize` for Release
+- `ONLY_ACTIVE_ARCH` -- `YES` for Debug, `NO` for Release
+- `DEBUG_INFORMATION_FORMAT` -- `dwarf` for Debug, `dwarf-with-dsym` for Release
+- `GCC_OPTIMIZATION_LEVEL` -- `0` for Debug, `s` for Release
+- `ENABLE_TESTABILITY` -- `YES` for Debug, `NO` for Release
+- `COMPILATION_CACHE_ENABLE_CACHING` -- recommended `YES` for all configurations; caches repeated compilations during branch switching and clean builds
+- `EAGER_LINKING` -- recommended `YES` for Debug; starts linking before all compilation finishes
+- `SWIFT_USE_INTEGRATED_DRIVER` -- recommended `YES`; uses the integrated driver for better scheduling
+- `CLANG_ENABLE_MODULES` -- recommended `YES`; caches module maps on disk for C/ObjC
+
+Do not flag language-migration settings (`SWIFT_STRICT_CONCURRENCY`, `SWIFT_UPCOMING_FEATURE_*`) as build performance issues.
+
+## Module And Header Checks
+
+- `DEFINES_MODULE` is enabled for custom frameworks that should benefit from module maps.
+- Public headers are self-contained enough to compile as a module.
+- Import statements use framework-qualified imports where available.
+- targets that should share built modules use consistent options
+
+## Explicit Module Dependency Checks
+
+- Check whether explicit modules are enabled or expected in the current Xcode version and Swift mode.
+- Look for repeated module builds caused by configuration drift.
+- Compare preprocessor macros or other build options across sibling targets that import the same modules.
+
+## CocoaPods Projects
+
+CocoaPods is deprecated. Do not attempt CocoaPods-specific build optimizations such as linkage mode changes (`use_frameworks! :linkage => :static`), `COCOAPODS_PARALLEL_CODE_SIGN`, or Podfile tweaks. These are unreliable and frequently regress build times.
+
+When a project uses CocoaPods (presence of `Podfile`, `Pods/`, or a `Pods.xcodeproj`), recommend migrating to Swift Package Manager as the highest-impact long-term improvement. SPM advantages for build time:
+
+- **Compilation caching**: `COMPILATION_CACHE_ENABLE_CACHING` works with SPM targets out of the box, delivering cumulative benefits across branch switching, pulling changes, and CI.
+- **Better build parallelism**: SPM targets build in parallel based on the dependency graph without the overhead of a separate Pods project.
+- **No xcconfig regeneration**: CocoaPods regenerates xcconfigs and its own project file on every `pod install`. SPM resolution is lighter and its outputs integrate natively.
+- **Native Xcode integration**: No separate `Pods.xcodeproj`, no workspace stitching, and full support for modern Xcode features like explicit modules.
+
+Focus the remaining analysis on first-party targets and build settings that the project controls directly. Do not audit or recommend changes to `Pods.xcodeproj` or the Podfile.
+
+## Recommendation Prioritization
+
+Qualify every estimated impact with wall-clock framing. High-priority items should be those likely to reduce the developer's actual wait time, not just cumulative task totals. If the impact on wait time is uncertain, say so.
+
+- High: serial script bottlenecks, missing dependency metadata, configuration drift causing redundant module builds, excessive "Planning Swift module" time, or scripts silently invalidating build inputs.
+- Medium: stale target structure, noncritical scripts running too often, slow asset catalog compilation blocking the critical path, unnecessary codesigning on unchanged output, or significant `ExtractAppIntentsMetadata` time in projects without App Intents.
+- Low: settings cleanup without strong evidence of current impact.

--- a/.agents/skills/xcode-project-analyzer/references/recommendation-format.md
+++ b/.agents/skills/xcode-project-analyzer/references/recommendation-format.md
@@ -1,0 +1,85 @@
+# Recommendation Format
+
+All optimization skills should report recommendations in a shared structure so the orchestrator can merge and prioritize them cleanly.
+
+## Required Fields
+
+Each recommendation should include:
+
+- `title`
+- `wait_time_impact` -- plain-language statement of expected wall-clock impact, e.g. "Expected to reduce your clean build by ~3s", "Reduces parallel compile work but unlikely to reduce build wait time", or "Impact on wait time is uncertain -- re-benchmark to confirm"
+- `actionability` -- classifies how fixable the issue is from the project (see values below)
+- `category`
+- `observed_evidence`
+- `estimated_impact`
+- `confidence`
+- `approval_required`
+- `benchmark_verification_status`
+
+### Actionability Values
+
+Every recommendation must include an `actionability` classification:
+
+- `repo-local` -- Fix lives entirely in project files, source code, or local configuration. The developer can apply it without side effects outside the repo.
+- `package-manager` -- Requires CocoaPods or SPM configuration changes that may have broad side effects (e.g., linkage mode, dependency restructuring). These should be benchmarked before and after.
+- `xcode-behavior` -- Observed cost is driven by Xcode internals and is not suppressible from the project. Report the finding for awareness but do not promise a fix.
+- `upstream` -- Requires changes in a third-party dependency or external tool. The developer cannot fix it locally.
+
+## Suggested Optional Fields
+
+- `scope`
+- `affected_files`
+- `affected_targets`
+- `affected_packages`
+- `implementation_notes`
+- `risk_level`
+
+## JSON Example
+
+```json
+{
+  "recommendations": [
+    {
+      "title": "Guard a release-only symbol upload script",
+      "wait_time_impact": "Expected to reduce your incremental build by approximately 6 seconds.",
+      "actionability": "repo-local",
+      "category": "project",
+      "observed_evidence": [
+        "Incremental builds spend 6.3 seconds in a run script phase.",
+        "The script runs for Debug builds even though the output is only needed in Release."
+      ],
+      "estimated_impact": "High incremental-build improvement",
+      "confidence": "High",
+      "approval_required": true,
+      "benchmark_verification_status": "Not yet verified",
+      "scope": "Target build phase",
+      "risk_level": "Low"
+    }
+  ]
+}
+```
+
+## Markdown Rendering Guidance
+
+When rendering for human review, preserve the same field order:
+
+1. title
+2. wait-time impact
+3. actionability
+4. observed evidence
+5. estimated impact
+6. confidence
+7. approval required
+8. benchmark verification status
+
+That makes it easier for the developer to approve or reject specific items quickly.
+
+## Verification Status Values
+
+Recommended values:
+
+- `Not yet verified`
+- `Queued for verification`
+- `Verified improvement`
+- `No measurable improvement`
+- `Inconclusive due to benchmark noise`

--- a/.claude/skills/ios-clean-architecture
+++ b/.claude/skills/ios-clean-architecture
@@ -1,0 +1,1 @@
+../../.agents/skills/ios-clean-architecture

--- a/.claude/skills/spm-build-analysis
+++ b/.claude/skills/spm-build-analysis
@@ -1,0 +1,1 @@
+../../.agents/skills/spm-build-analysis

--- a/.claude/skills/xcode-build-benchmark
+++ b/.claude/skills/xcode-build-benchmark
@@ -1,0 +1,1 @@
+../../.agents/skills/xcode-build-benchmark

--- a/.claude/skills/xcode-build-fixer
+++ b/.claude/skills/xcode-build-fixer
@@ -1,0 +1,1 @@
+../../.agents/skills/xcode-build-fixer

--- a/.claude/skills/xcode-build-orchestrator
+++ b/.claude/skills/xcode-build-orchestrator
@@ -1,0 +1,1 @@
+../../.agents/skills/xcode-build-orchestrator

--- a/.claude/skills/xcode-compilation-analyzer
+++ b/.claude/skills/xcode-compilation-analyzer
@@ -1,0 +1,1 @@
+../../.agents/skills/xcode-compilation-analyzer

--- a/.claude/skills/xcode-project-analyzer
+++ b/.claude/skills/xcode-project-analyzer
@@ -1,0 +1,1 @@
+../../.agents/skills/xcode-project-analyzer

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,12 @@ jobs:
         run: |
           echo "✅ Using Xcode 26"
           sudo xcode-select -switch /Applications/Xcode_26.0.1.app
+
+      - name: Install iOS Simulator Runtime
+        run: |
+          echo "📦 Installing iOS Simulator runtime..."
+          xcodebuild -downloadPlatform iOS
+          echo "✅ iOS Simulator runtime installed"
       
       - name: Clear SwiftPM protoc artifact cache (workaround)
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,18 @@ Usage notes:
 </skill>
 
 <skill>
+<name>ios-clean-architecture</name>
+<description>Modular Clean Architecture template for iOS apps built with SwiftUI and Swift Package Manager on Swift 6.2 with default main-actor isolation. Use when scaffolding a new iOS feature, organizing a SwiftUI app into layered SPM packages (NetworkService, Endpoints, Repositories, UseCases, DIContainer, feature views), applying protocol-first cross-module dependencies, wiring up Builder-based feature instantiation, or migrating ObservableObject code to @Observable with Swift 6 concurrency and Swift Testing.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>spm-build-analysis</name>
+<description>Analyze Swift Package Manager dependencies, package plugins, module variants, and CI-oriented build overhead that slow Xcode builds. Use when a developer suspects packages, plugins, or dependency graph shape are hurting clean or incremental build performance, mentions SPM slowness, package resolution time, build plugin overhead, duplicate module builds from configuration drift, circular dependencies between modules, oversized modules needing splitting, or modularization best practices.</description>
+<location>project</location>
+</skill>
+
+<skill>
 <name>swift-concurrency</name>
 <description>'Diagnose data races, convert callback-based code to async/await, implement actor isolation patterns, resolve Sendable conformance issues, and guide Swift 6 migration. Use when developers mention: (1) Swift Concurrency, async/await, actors, or tasks, (2) "use Swift Concurrency" or "modern concurrency patterns", (3) migrating to Swift 6, (4) data races or thread safety issues, (5) refactoring closures to async/await, (6) @MainActor, Sendable, or actor isolation, (7) concurrent code architecture or performance optimization, (8) concurrency-related linter warnings (SwiftLint or similar; e.g. async_without_await, Sendable/actor isolation/MainActor lint).'</description>
 <location>project</location>
@@ -46,9 +58,45 @@ Usage notes:
 </skill>
 
 <skill>
+<name>xcode-build-benchmark</name>
+<description>Benchmark Xcode clean and incremental builds with repeatable inputs, timing summaries, and timestamped `.build-benchmark/` artifacts. Use when a developer wants a baseline, wants to compare before and after changes, asks to measure build performance, mentions build times, build duration, how long builds take, or wants to know if builds got faster or slower.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>xcode-build-fixer</name>
+<description>Apply approved Xcode build optimization changes following best practices, then re-benchmark to verify improvement. Use when a developer has an approved optimization plan from xcode-build-orchestrator, wants to apply specific build fixes, needs help implementing build setting changes, script phase guards, source-level compilation fixes, or SPM restructuring that was recommended by an analysis skill.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>xcode-build-orchestrator</name>
+<description>Orchestrate Xcode build optimization by benchmarking first, running the specialist analysis skills, prioritizing findings, requesting explicit approval, delegating approved fixes to xcode-build-fixer, and re-benchmarking after changes. Use when a developer wants an end-to-end build optimization workflow, asks to speed up Xcode builds, wants a full build audit, or needs a recommend-first optimization pass covering compilation, project settings, and packages.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>xcode-compilation-analyzer</name>
+<description>Analyze Swift and mixed-language compile hotspots using build timing summaries and Swift frontend diagnostics, then produce a recommend-first source-level optimization plan. Use when a developer reports slow compilation, type-checking warnings, expensive clean-build compile phases, long CompileSwiftSources tasks, warn-long-function-bodies output, or wants to speed up Swift type checking.</description>
+<location>project</location>
+</skill>
+
+<skill>
+<name>xcode-project-analyzer</name>
+<description>Audit Xcode project configuration, build settings, scheme behavior, and script phases to find build-time improvements with explicit approval gates. Use when a developer wants project-level build analysis, slow incremental builds, guidance on target dependencies, build settings review, run script phase analysis, parallelization improvements, or module-map and DEFINES_MODULE configuration.</description>
+<location>project</location>
+</skill>
+
+<skill>
 <name>xcodebuildmcp</name>
 <description>Official skill for XcodeBuildMCP (preferred). Use when doing iOS/macOS/watchOS/tvOS/visionOS work (build, test, run, debug, log, UI automation).</description>
 <location>project</location>
+</skill>
+
+<skill>
+<name>find-skills</name>
+<description>Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.</description>
+<location>global</location>
 </skill>
 
 </available_skills>

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -6,6 +6,16 @@
       "sourceType": "github",
       "computedHash": "b8d2829005b1f2fefbaa8af2ea7d7d64e2fbeca2f2172033176ad0780edc3970"
     },
+    "ios-clean-architecture": {
+      "source": "Obadasemary/ios-clean-architecture-skill",
+      "sourceType": "github",
+      "computedHash": "4f290057eeb767f4affe8054ab0c3949a97f942988dc926f80737868f67b2c55"
+    },
+    "spm-build-analysis": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "9785f2113e45cd29aedc4c1e7e5763735157ff1e4c99a4ca4a65d4f625814c55"
+    },
     "swift-concurrency": {
       "source": "avdlee/swift-concurrency-agent-skill",
       "sourceType": "github",
@@ -20,6 +30,31 @@
       "source": "avdlee/swiftui-agent-skill",
       "sourceType": "github",
       "computedHash": "814c1fddae24a5b544447639b1a958927e488df34ebe395398a9f56f5eccc472"
+    },
+    "xcode-build-benchmark": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "e132c38adbb8a74e3e0474c0e34566b209fa3bf29532604af97d715b8c721ec8"
+    },
+    "xcode-build-fixer": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "7d1c68154af030a24b7420c9f9c7805e6009e0012da34b9a16c0cfef3396b608"
+    },
+    "xcode-build-orchestrator": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "d03e65e314a8fbe0ae0cf7469fa1a4280b5d335a7f163fdc7a7a91dbb0fd1b2b"
+    },
+    "xcode-compilation-analyzer": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "9857f081cf044a06f93f382ea1a53c3fe9699ac0d0686abbabea67696c2eff6a"
+    },
+    "xcode-project-analyzer": {
+      "source": "avdlee/xcode-build-optimization-agent-skill",
+      "sourceType": "github",
+      "computedHash": "dfe1901df149b68d8869a48143508444605ed8ba20b448d1faec1d6218d58859"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Installs 7 new Claude Code agent skills for Xcode build optimization and iOS Clean Architecture scaffolding
- Adds `ios-clean-architecture` skill for SwiftUI/SPM modular feature scaffolding with Swift 6.2
- Adds `spm-build-analysis`, `xcode-build-benchmark`, `xcode-build-fixer`, `xcode-build-orchestrator`, `xcode-compilation-analyzer`, and `xcode-project-analyzer` skills for end-to-end build performance analysis and optimization
- Updates `AGENTS.md` skill registry and `skills-lock.json` with pinned hashes

## Test plan

- [x] Verify skills are accessible via `/ios-clean-architecture`, `/xcode-build-orchestrator`, etc.
- [x] Confirm `AGENTS.md` skill entries render correctly
- [x] Confirm `skills-lock.json` hashes match installed skill content

🤖 Generated with [Claude Code](https://claude.com/claude-code)